### PR TITLE
Properly migrate manuals

### DIFF
--- a/document_page_environment_manual/migrations/7.0.1.0/pre-migration.py
+++ b/document_page_environment_manual/migrations/7.0.1.0/pre-migration.py
@@ -22,9 +22,18 @@
 
 import logging
 logger = logging.getLogger('upgrade')
+logger.setLevel(logging.DEBUG)
+
+xmlid_renames = [
+    ('document_page_environment_manual.wiki_environment_manual',
+     'document_page_environment_manual.document_page_environment_manual'),
+]
 
 
 def logged_query(cr, query, args=None):
+    """
+    Logs query and affected rows at level DEBUG
+    """
     if args is None:
         args = []
     cr.execute(query, args)
@@ -33,21 +42,25 @@ def logged_query(cr, query, args=None):
     return cr.rowcount
 
 
-def pre_migrate_environment_manual_category(cr, version):
-    logged_query(cr, """\
-UPDATE document_page
-SET parent_id = (SELECT id FROM document_page WHERE name = 'Manuals' LIMIT 1),
-    name = name || ' (' || %s || ')'
-WHERE parent_id = (SELECT id FROM document_page
-                   WHERE name = 'Environment Manual' AND type = 'category')
-     AND type = 'content';""", [version])
-    logged_query(cr, """\
-UPDATE document_page
-SET name = name || ' (' || %s || ')'
-WHERE name = 'Environment Manual' AND type = 'category';""", [version])
+def rename_xmlids(cr, xmlids_spec):
+    """
+    Rename XML IDs. Typically called in the pre script.
+    One usage example is when an ID changes module. In OpenERP 6 for example,
+    a number of res_groups IDs moved to module base from other modules (
+    although they were still being defined in their respective module).
+    """
+    for (old, new) in xmlids_spec:
+        if not old.split('.') or not new.split('.'):
+            logger.error(
+                'Cannot rename XMLID %s to %s: need the module '
+                'reference to be specified in the IDs' % (old, new))
+        else:
+            query = ("UPDATE ir_model_data SET module = %s, name = %s "
+                     "WHERE module = %s and name = %s")
+            logged_query(cr, query, tuple(new.split('.') + old.split('.')))
 
 
 def migrate(cr, version):
     if version is None:
         return
-    pre_migrate_environment_manual_category(cr, version)
+    rename_xmlids(cr, xmlid_renames)

--- a/document_page_environmental_aspect/migrations/7.0.1.0/pre-migration.py
+++ b/document_page_environmental_aspect/migrations/7.0.1.0/pre-migration.py
@@ -22,9 +22,21 @@
 
 import logging
 logger = logging.getLogger('upgrade')
+logger.setLevel(logging.DEBUG)
+
+xmlid_renames = [
+    ('document_page_environmental_aspect.wiki_environmental_aspect',
+     'document_page_environmental_aspect.document_page_environmental_aspect'),
+    ('document_page_environmental_aspect.wiki_group_environmental_aspect',
+     'document_page_environmental_aspect.\
+     document_page_group_environmental_aspect'),
+]
 
 
 def logged_query(cr, query, args=None):
+    """
+    Logs query and affected rows at level DEBUG
+    """
     if args is None:
         args = []
     cr.execute(query, args)
@@ -33,31 +45,25 @@ def logged_query(cr, query, args=None):
     return cr.rowcount
 
 
-def post_migrate_category(cr, version, category):
-    logged_query(cr, """\
-UPDATE document_page
-SET parent_id = (SELECT id FROM document_page
-                 WHERE name = %s AND type = 'category'
-                 ORDER BY id DESC
-                 LIMIT 1),
-    name = name || ' (' || %s || ')'
-WHERE parent_id = (SELECT id FROM document_page
-                   WHERE name = %s AND type = 'category'
-                   ORDER BY id ASC
-                   LIMIT 1)
-     AND type = 'content';""", (category, version, category))
-    logged_query(cr, """\
-UPDATE document_page
-SET name = name || ' (' || %s || ')'
-WHERE id = (SELECT id FROM document_page
-            WHERE name = %s AND type = 'category'
-            ORDER BY id ASC
-            LIMIT 1)
-     AND type = 'category';""", (version, category))
+def rename_xmlids(cr, xmlids_spec):
+    """
+    Rename XML IDs. Typically called in the pre script.
+    One usage example is when an ID changes module. In OpenERP 6 for example,
+    a number of res_groups IDs moved to module base from other modules (
+    although they were still being defined in their respective module).
+    """
+    for (old, new) in xmlids_spec:
+        if not old.split('.') or not new.split('.'):
+            logger.error(
+                'Cannot rename XMLID %s to %s: need the module '
+                'reference to be specified in the IDs' % (old, new))
+        else:
+            query = ("UPDATE ir_model_data SET module = %s, name = %s "
+                     "WHERE module = %s and name = %s")
+            logged_query(cr, query, tuple(new.split('.') + old.split('.')))
 
 
 def migrate(cr, version):
     if version is None:
         return
-    post_migrate_category(cr, version, 'Procedure')
-    post_migrate_category(cr, version, 'Work Instructions')
+    rename_xmlids(cr, xmlid_renames)

--- a/document_page_health_safety_manual/migrations/7.0.1.0/post-migration.py
+++ b/document_page_health_safety_manual/migrations/7.0.1.0/post-migration.py
@@ -25,8 +25,8 @@ logger = logging.getLogger('upgrade')
 logger.setLevel(logging.DEBUG)
 
 xmlid_renames = [
-    ('document_page_quality_manual.system_quality',
-     'document_page_quality_manual.document_page_quality_manual'),
+    ('document_page_health_safety_manual.wiki_health_safety_manual',
+     'document_page_health_safety_manual.document_page_health_safety_manual'),
 ]
 
 

--- a/document_page_procedure/migrations/7.0.1.0/pre-migration.py
+++ b/document_page_procedure/migrations/7.0.1.0/pre-migration.py
@@ -22,9 +22,20 @@
 
 import logging
 logger = logging.getLogger('upgrade')
+logger.setLevel(logging.DEBUG)
+
+xmlid_renames = [
+    ('document_page_procedure.wiki_procedure',
+     'document_page_procedure.document_page_procedure'),
+    ('document_page_procedure.wiki_group_procedure',
+     'document_page_procedure.document_page_group_procedure'),
+]
 
 
 def logged_query(cr, query, args=None):
+    """
+    Logs query and affected rows at level DEBUG
+    """
     if args is None:
         args = []
     cr.execute(query, args)
@@ -33,30 +44,25 @@ def logged_query(cr, query, args=None):
     return cr.rowcount
 
 
-def post_migrate_category(cr, version, category):
-    logged_query(cr, """\
-UPDATE document_page
-SET parent_id = (SELECT id FROM document_page
-                 WHERE name = %s AND type = 'category'
-                 ORDER BY id DESC
-                 LIMIT 1),
-    name = name || ' (' || %s || ')'
-WHERE parent_id = (SELECT id FROM document_page
-                   WHERE name = %s AND type = 'category'
-                   ORDER BY id ASC
-                   LIMIT 1)
-     AND type = 'content';""", (category, version, category))
-    logged_query(cr, """\
-UPDATE document_page
-SET name = name || ' (' || %s || ')'
-WHERE id = (SELECT id FROM document_page
-            WHERE name = %s AND type = 'category'
-            ORDER BY id ASC
-            LIMIT 1)
-     AND type = 'category';""", (version, category))
+def rename_xmlids(cr, xmlids_spec):
+    """
+    Rename XML IDs. Typically called in the pre script.
+    One usage example is when an ID changes module. In OpenERP 6 for example,
+    a number of res_groups IDs moved to module base from other modules (
+    although they were still being defined in their respective module).
+    """
+    for (old, new) in xmlids_spec:
+        if not old.split('.') or not new.split('.'):
+            logger.error(
+                'Cannot rename XMLID %s to %s: need the module '
+                'reference to be specified in the IDs' % (old, new))
+        else:
+            query = ("UPDATE ir_model_data SET module = %s, name = %s "
+                     "WHERE module = %s and name = %s")
+            logged_query(cr, query, tuple(new.split('.') + old.split('.')))
 
 
 def migrate(cr, version):
     if version is None:
         return
-    post_migrate_category(cr, version, 'Work Instructions')
+    rename_xmlids(cr, xmlid_renames)

--- a/document_page_work_instructions/migrations/7.0.1.0/pre-migration.py
+++ b/document_page_work_instructions/migrations/7.0.1.0/pre-migration.py
@@ -22,9 +22,20 @@
 
 import logging
 logger = logging.getLogger('upgrade')
+logger.setLevel(logging.DEBUG)
+
+xmlid_renames = [
+    ('document_page_work_instructions.wiki_work_instruction',
+     'document_page_work_instructions.document_page_work_instruction'),
+    ('document_page_work_instructions.wiki_group_work_instructions',
+     'document_page_work_instructions.document_page_group_work_instructions'),
+]
 
 
 def logged_query(cr, query, args=None):
+    """
+    Logs query and affected rows at level DEBUG
+    """
     if args is None:
         args = []
     cr.execute(query, args)
@@ -33,30 +44,25 @@ def logged_query(cr, query, args=None):
     return cr.rowcount
 
 
-def post_migrate_environmental_aspect_category(cr, version):
-    logged_query(cr, """\
-UPDATE document_page
-SET parent_id = (SELECT id FROM document_page
-                 WHERE name = 'Environmental Aspect' AND type = 'category'
-                 ORDER BY id DESC
-                 LIMIT 1),
-    name = name || ' (' || %s || ')'
-WHERE parent_id = (SELECT id FROM document_page
-                   WHERE name = 'Environmental Aspect' AND type = 'category'
-                   ORDER BY id ASC
-                   LIMIT 1)
-     AND type = 'content';""", [version])
-    logged_query(cr, """\
-UPDATE document_page
-SET name = name || ' (' || %s || ')'
-WHERE id = (SELECT id FROM document_page
-            WHERE name = 'Environmental Aspect' AND type = 'category'
-            ORDER BY id ASC
-            LIMIT 1)
-     AND type = 'category';""", [version])
+def rename_xmlids(cr, xmlids_spec):
+    """
+    Rename XML IDs. Typically called in the pre script.
+    One usage example is when an ID changes module. In OpenERP 6 for example,
+    a number of res_groups IDs moved to module base from other modules (
+    although they were still being defined in their respective module).
+    """
+    for (old, new) in xmlids_spec:
+        if not old.split('.') or not new.split('.'):
+            logger.error(
+                'Cannot rename XMLID %s to %s: need the module '
+                'reference to be specified in the IDs' % (old, new))
+        else:
+            query = ("UPDATE ir_model_data SET module = %s, name = %s "
+                     "WHERE module = %s and name = %s")
+            logged_query(cr, query, tuple(new.split('.') + old.split('.')))
 
 
 def migrate(cr, version):
     if version is None:
         return
-    post_migrate_environmental_aspect_category(cr, version)
+    rename_xmlids(cr, xmlid_renames)

--- a/mgmtsystem_manuals/migrations/7.0.1.0/pre-migration.py
+++ b/mgmtsystem_manuals/migrations/7.0.1.0/pre-migration.py
@@ -25,8 +25,8 @@ logger = logging.getLogger('upgrade')
 logger.setLevel(logging.DEBUG)
 
 xmlid_renames = [
-    ('document_page_quality_manual.system_quality',
-     'document_page_quality_manual.document_page_quality_manual'),
+    ('document_page_quality_manual.wiki_group_quality_manual',
+     'mgmtsystem_manuals.manuals'),
 ]
 
 


### PR DESCRIPTION
Redo implementation which duplicated manuals before.
Since these are datas, they should not be backed up, the xmlids need to be
renamed.

Depends on the following to be fully OpenUpgrade compatible:
- https://code.launchpad.net/~savoirfairelinux/openupgrade-server/rename_ir_model_data/+merge/231599
- https://code.launchpad.net/~savoirfairelinux/openupgrade-addons/document_page_ir_model_data/+merge/231615
