### PR TITLE
[FIX] ValueError: Invalid field 'fold' in leaf "<osv.ExtendedLeaf: ('…

### DIFF
--- a/mgmtsystem_action/mgmtsystem_action.xml
+++ b/mgmtsystem_action/mgmtsystem_action.xml
@@ -84,6 +84,7 @@
       <field name="view_id" ref="view_mgmtsystem_action_tree"/>
       <field name="search_view_id" ref="view_mgmtsystem_action_filter"/>
       <field name="context">{"search_default_current":1,"search_default_user_id":uid}</field>
+      <field name="domain"></field>
     </record>
 
     <menuitem id="menu_open_action" 


### PR DESCRIPTION
…fold', '=', False) on mgmtsystem_action_stage (ctx: )>"

Otherwise the domain is set with `[('fold', '=', False)]` and raises the error.
