### PR TITLE
[9.0][FIX] mgmtsystem_nonconformity for migration

### DIFF
--- a/mgmtsystem_nonconformity/models/mgmtsystem_nonconformity.py
+++ b/mgmtsystem_nonconformity/models/mgmtsystem_nonconformity.py
@@ -16,7 +16,9 @@ class MgmtsystemNonconformity(models.Model):
 
     def _default_stage(self):
         """Return the default stage."""
-        return self.env.ref('mgmtsystem_nonconformity.stage_draft')
+        return (
+            self.env.ref('mgmtsystem_nonconformity.stage_draft', False) or
+            self.env['mgmtsystem.nonconformity.stage'])
 
     @api.model
     def _stage_groups(self, present_ids, domain, **kwargs):


### PR DESCRIPTION
For eg. if you are running an upgrade from v8 to v9, when new column "stage_id" is created on module upgrade, default value whant to be computed using "self.env.ref('mgmtsystem_nonconformity.stage_draft')" but stages has not been loaded yet

We fix this so if no "mgmtsystem_nonconformity.stage_draft" is found none default stage is configured (stage field is not mandatory)