### PR TITLE
Fix design issue in models/mgmtsystem_nonconformity.py

### DIFF
--- a/mgmtsystem_nonconformity/demo/mgmtsystem_nonconformity.xml
+++ b/mgmtsystem_nonconformity/demo/mgmtsystem_nonconformity.xml
@@ -2,22 +2,21 @@
 <odoo>
     <data>
 
-        <record id="demo_nonconformity" model="mgmtsystem.nonconformity">
-            <field name="partner_id" ref="base.res_partner_3"/>
-            <field name="create_date">2010-12-03</field>
-            <field name="name">Demo Nonconformity</field>
-            <field name="responsible_user_id" ref="base.user_demo"/>
-            <field name="manager_user_id" ref="base.user_root"/>
-            <field name="user_id" ref="base.user_demo"/>
-            <field name="description">The procedure has changed with no comments on the revision.</field>
-            <field name="analysis">Administrator didn't know he had to add a comment when changing the procedure.</field>
-            <field name="origin_ids" eval="[(6,0,[ref('demo_origin')])]"/>
-            <field name="procedure_ids" eval="[(6,0,[ref('document_page_procedure.document_page_procedure')])]"/>
-            <field name="cause_ids" eval="[(6,0,[ref('demo_cause')])]"/>
-            <field name="immediate_action_id" ref="mgmtsystem_action.demo_immediate"/>
-            <field name="corrective_action_id" ref="mgmtsystem_action.demo_corrective"/>
-            <field name="preventive_action_id" ref="mgmtsystem_action.demo_preventive"/>
-        </record>
+    <record id="demo_nonconformity" model="mgmtsystem.nonconformity">
+        <field name="partner_id" ref="base.res_partner_3"/>
+        <field name="create_date">2010-12-03</field>
+        <field name="name">Demo Nonconformity</field>
+        <field name="responsible_user_id" ref="base.user_demo"/>
+        <field name="manager_user_id" ref="base.user_root"/>
+        <field name="user_id" ref="base.user_demo"/>
+        <field name="description">The procedure has changed with no comments on the revision.</field>
+        <field name="analysis">Administrator didn't know he had to add a comment when changing the procedure.</field>
+        <field name="origin_ids" eval="[(6,0,[ref('demo_origin')])]"/>
+        <field name="procedure_ids" eval="[(6,0,[ref('document_page_procedure.document_page_procedure')])]"/>
+        <field name="cause_ids" eval="[(6,0,[ref('demo_cause')])]"/>
+        <field name="immediate_action_id" ref="mgmtsystem_action.demo_immediate"/>
+        <field name="action_ids" eval="[(6, 0, [ref('mgmtsystem_action.demo_immediate'), ref('mgmtsystem_action.demo_corrective'), ref('mgmtsystem_action.demo_preventive')])]"/>
+    </record>
 
     </data>
 </odoo>

--- a/mgmtsystem_nonconformity/models/mgmtsystem_nonconformity.py
+++ b/mgmtsystem_nonconformity/models/mgmtsystem_nonconformity.py
@@ -163,23 +163,12 @@ class MgmtsystemNonconformity(models.Model):
         'Company',
         default=lambda self: self.env.user.company_id.id)
 
-    corrective_action_id = fields.Many2one(
-        'mgmtsystem.action',
-        'Corrective action',
-        domain="[('nonconformity_id', '=', id)]",
-    )
-    preventive_action_id = fields.Many2one(
-        'mgmtsystem.action',
-        'Preventive action',
-        domain="[('nonconformity_id', '=', id)]",
-    )
-
     @api.multi
     def _get_all_actions(self):
         self.ensure_one()
-        return (self.action_ids +
-                self.corrective_action_id +
-                self.preventive_action_id)
+        return (
+            self.action_ids +
+            self.immediate_action_id)
 
     @api.constrains('stage_id')
     def _check_open_with_action_comments(self):

--- a/mgmtsystem_nonconformity/tests/test_nonconformity.py
+++ b/mgmtsystem_nonconformity/tests/test_nonconformity.py
@@ -18,9 +18,9 @@ class TestModelNonConformity(common.TransactionCase):
             'description': "description",
             'responsible_user_id': self.env.user.id,
             })
-        action_vals = {'name': 'An Action', 'type_action': 'correction'}
+        action_vals = {'name': 'An Action', 'type_action': 'immediate'}
         action1 = self.nc_model.action_ids.create(action_vals)
-        self.nc_test.corrective_action_id = action1
+        self.nc_test.immediate_action_id = action1
 
     def test_stage_group(self):
         """Group by Stage shows all stages"""
@@ -47,12 +47,15 @@ class TestModelNonConformity(common.TransactionCase):
     def test_done_validation(self):
         """Don't allow closing an NC without evaluation comments"""
         done_stage = self.env.ref('mgmtsystem_nonconformity.stage_done')
+        self.nc_test.action_comments = 'OK!'
         with self.assertRaises(ValidationError):
             self.nc_test.stage_id = done_stage
 
     def test_done_actions_validation(self):
         """Don't allow closing an NC with open actions"""
         done_stage = self.env.ref('mgmtsystem_nonconformity.stage_done')
+        self.nc_test.immediate_action_id.stage_id = \
+            self.env.ref('mgmtsystem_action.stage_open')
         self.nc_test.evaluation_comments = 'OK!'
         with self.assertRaises(ValidationError):
             self.nc_test.stage_id = done_stage
@@ -63,12 +66,14 @@ class TestModelNonConformity(common.TransactionCase):
         self.nc_test.stage_id = self.env.ref(
             'mgmtsystem_nonconformity.stage_open')
         self.assertEqual(
-            self.nc_test.corrective_action_id.stage_id,
+            self.nc_test.immediate_action_id.stage_id,
             self.env.ref('mgmtsystem_action.stage_open'),
             'Plan Approval starts Actions')
 
+        self.nc_test.immediate_action_id.stage_id = \
+            self.env.ref('mgmtsystem_action.stage_open')
         self.nc_test.evaluation_comments = 'OK!'
-        self.nc_test.corrective_action_id.stage_id = \
+        self.nc_test.immediate_action_id.stage_id = \
             self.env.ref('mgmtsystem_action.stage_close')
         self.nc_test.stage_id = self.env.ref(
             'mgmtsystem_nonconformity.stage_done')


### PR DESCRIPTION
preventive_action_id and corrective_action_id are nowhere to be located in the view definition, making it impossible to close a NC that has preventive and corrective actions assignet to it.

![ncs_views_v9](https://cloud.githubusercontent.com/assets/8398291/25425410/2d9c8892-2a6c-11e7-8a7f-36b50a756085.png)
