### PR TITLE
[10.0][FIX] Causes selection in a nonconformity

### DIFF
--- a/mgmtsystem_nonconformity/views/mgmtsystem_nonconformity.xml
+++ b/mgmtsystem_nonconformity/views/mgmtsystem_nonconformity.xml
@@ -158,7 +158,15 @@
                 <field name="analysis" attrs="{'readonly':[('state','not in',['analysis'])]}"/>
 
                 <separator string="Causes"/>
-                <field name="cause_ids" attrs="{'readonly':[('state','not in',['analysis'])]}"/>
+                <field name="cause_ids" attrs="{'readonly':[('state','not in',['analysis'])]}"
+                       options="{'no_create': True}">
+                  <tree create="1" delete="1" colors="blue:parent_id;">
+                    <field name="parent_id"/>
+                    <field name="name"/>
+                    <field name="description"/>
+                    <field name="sequence"/>
+                  </tree>
+                </field>
 
                 <separator string="Analysis Confirmation"/>
                 <group>


### PR DESCRIPTION
A simple management user has no create/delete rights on nonconformity causes. Then, he is not able to select/deselect causes on a nonconformity.