### PR TITLE
[10.0][FIX] Auditor/Auditee selection in an audit

### DIFF
--- a/mgmtsystem_audit/__manifest__.py
+++ b/mgmtsystem_audit/__manifest__.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "Management System - Audit",
-    "version": "10.0.1.0.0",
+    "version": "10.0.1.0.1",
     "author": "Savoir-faire Linux, Odoo Community Association (OCA)",
     "website": "http://www.savoirfairelinux.com",
     "license": "AGPL-3",
@@ -15,6 +15,7 @@
         'data/audit_sequence.xml',
         'data/audit_automated_actions.xml',
         'views/mgmtsystem_audit.xml',
+        'views/res_users.xml',
         'report/audit.xml',
         'report/verification.xml',
         'report/report.xml',

--- a/mgmtsystem_audit/views/mgmtsystem_audit.xml
+++ b/mgmtsystem_audit/views/mgmtsystem_audit.xml
@@ -122,10 +122,14 @@
                         </group>
                         <notebook colspan="4">
                             <page string="Auditors">
-                                <field name="auditor_user_ids" nolabel="1" attrs="{'readonly':[('state','=','done')]}"/>
+                                <field name="auditor_user_ids" nolabel="1" attrs="{'readonly':[('state','=','done')]}"
+                                       options="{'no_create': True}"
+                                       context="{'tree_view_ref': 'mgmtsystem_audit.mgmtsystem_audit_res_users_x2m_tree'}"/>
                             </page>
                             <page string="Auditees">
-                                <field name="auditee_user_ids" nolabel="1" attrs="{'readonly':[('state','=','done')]}"/>
+                                <field name="auditee_user_ids" nolabel="1" attrs="{'readonly':[('state','=','done')]}"
+                                       options="{'no_create': True}"
+                                       context="{'tree_view_ref': 'mgmtsystem_audit.mgmtsystem_audit_res_users_x2m_tree'}"/>
                             </page>
                             <page string="Verification List">
                                 <field name="line_ids" nolabel="1" attrs="{'readonly':[('state','=','done')]}"/>

--- a/mgmtsystem_audit/views/res_users.xml
+++ b/mgmtsystem_audit/views/res_users.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2017 ACSONE SA/NV
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+
+<odoo>
+
+    <record model="ir.ui.view" id="mgmtsystem_audit_res_users_x2m_tree">
+        <field name="name">mgmtsystem.audit.res.users.x2m.tree (in mgmtsystem_audit)</field>
+        <field name="model">res.users</field>
+        <field name="arch" type="xml">
+            <tree create="1" delete="1">
+                <field name="name"/>
+                <field name="login"/>
+                <field name="lang"/>
+                <field name="login_date"/>
+            </tree>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
A manager has no create/delete rights on users. Then, he is not able to select/deselect users on an audit.