### PR TITLE
[FIX] default date unnecessary

### DIFF
--- a/mgmtsystem_action/models/mgmtsystem_action.py
+++ b/mgmtsystem_action/models/mgmtsystem_action.py
@@ -52,8 +52,7 @@ class MgmtsystemAction(models.Model):
     active = fields.Boolean('Active', default=True)
     date_deadline = fields.Date('Deadline')
 
-    create_date = fields.Datetime('Create Date', readonly=True,
-                                  default=fields.datetime.now())
+    create_date = fields.Datetime('Create Date', readonly=True)
     cancel_date = fields.Datetime('Cancel Date', readonly=True)
     opening_date = fields.Datetime('Opening Date', readonly=True)
     date_closed = fields.Datetime('Closed Date', readonly=True)


### PR DESCRIPTION
I think it is unnecessary to have default date calculated on this field.
Because first this field is readonly
Second ORM will override the value
Finally, the value seen by the user is the start date of the server... not "date now". And even if it was the current date a few minutes passed before the creation, the displayed time is no longer correct.