### PR TITLE
[FIX] Set create_date as readonly because it can't be changed anyway

### DIFF
--- a/mgmtsystem_nonconformity/views/mgmtsystem_nonconformity.xml
+++ b/mgmtsystem_nonconformity/views/mgmtsystem_nonconformity.xml
@@ -129,7 +129,7 @@
               <group>
                 <field name="name" attrs="{'readonly':[('state','not in',['draft'])]}"/>
                 <field name="ref" attrs="{'readonly':[('state','not in',['draft'])]}"/>
-                <field name="create_date" attrs="{'readonly':[('state','not in',['draft'])]}"/>
+                <field name="create_date" readonly="1"/>
                 <field name="partner_id" attrs="{'readonly':[('state','not in',['draft','analysis'])]}"/>
                 <field name="reference" attrs="{'readonly':[('state','not in',['draft'])]}"/>
                 <field name="origin_ids" widget="many2many_tags" attrs="{'readonly':[('state','not in',['draft','analysis'])]}"/>


### PR DESCRIPTION
```create_date``` can't be edited. If we want an editable date field, we should add another one.