### PR TITLE
mgmtsystem: Access rights for document pages

### DIFF
--- a/document_page_environmental_aspect/__manifest__.py
+++ b/document_page_environmental_aspect/__manifest__.py
@@ -20,7 +20,7 @@
 ##############################################################################
 {
     "name": "Environmental Aspects",
-    "version": "9.0.1.0.0",
+    "version": "10.0.1.0.0",
     "author": "Savoir-faire Linux, Odoo Community Association (OCA)",
     "website": "http://www.savoirfairelinux.com",
     "license": "AGPL-3",
@@ -32,6 +32,7 @@
     "data": [
         'data/document_page.xml',
         'views/document_page.xml',
+        'security/environmental_aspect_security.xml',
     ],
-    'installable': False,
+    'installable': True,
 }

--- a/document_page_environmental_aspect/security/environmental_aspect_security.xml
+++ b/document_page_environmental_aspect/security/environmental_aspect_security.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Read/Write/Create/Unlink access in 'Management System / viewer' group
+        to 'Environmental aspect' documents -->
+    <record id="environmental_document_rule_mgmtsystem_viewer" model="ir.rule">
+        <field name="name">Environmental document page for viewers</field>
+        <field name="model_id" ref="document_page.model_document_page"/>
+        <field name="domain_force" eval="['|', ('parent_id','=',ref('document_page_group_environmental_aspect')), ('id','=',ref('document_page_group_environmental_aspect'))]"/>
+        <field name="groups" eval="[(4, ref('mgmtsystem.group_mgmtsystem_viewer'))]"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="True"/>
+        <field name="perm_create" eval="True"/>
+        <field name="perm_unlink" eval="True"/>
+    </record>
+
+    <record id="environmental_document_history_rule_mgmtsystem_viewer" model="ir.rule">
+        <field name="name">Environmental document page for viewers</field>
+        <field name="model_id" ref="document_page.model_document_page_history"/>
+        <field name="domain_force" eval="['|', ('page_id.parent_id','=',ref('document_page_group_environmental_aspect')), ('page_id','=',ref('document_page_group_environmental_aspect'))]"/>
+        <field name="groups" eval="[(4, ref('mgmtsystem.group_mgmtsystem_viewer'))]"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="True"/>
+        <field name="perm_create" eval="True"/>
+        <field name="perm_unlink" eval="True"/>
+    </record>
+</odoo>

--- a/document_page_procedure/__manifest__.py
+++ b/document_page_procedure/__manifest__.py
@@ -15,6 +15,7 @@
     "data": [
         'data/document_page_procedure.xml',
         'views/document_page_procedure.xml',
+        'security/procedure_security.xml',
     ],
     "demo": [
         'demo/document_page_procedure.xml',

--- a/document_page_procedure/security/procedure_security.xml
+++ b/document_page_procedure/security/procedure_security.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Read/Write/Create/Unlink access in 'Management System / viewer' group
+        to 'Procedure' documents -->
+    <record id="procedure_document_rule_mgmtsystem_viewer" model="ir.rule">
+        <field name="name">Procedure document page for viewers</field>
+        <field name="model_id" ref="document_page.model_document_page"/>
+        <field name="domain_force" eval="['|', ('parent_id','=',ref('document_page_group_procedure')), ('id','=',ref('document_page_group_procedure'))]"/>
+        <field name="groups" eval="[(4, ref('mgmtsystem.group_mgmtsystem_viewer'))]"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="True"/>
+        <field name="perm_create" eval="True"/>
+        <field name="perm_unlink" eval="True"/>
+    </record>
+
+    <record id="procedure_document_history_rule_mgmtsystem_viewer" model="ir.rule">
+        <field name="name">Procedure document page for viewers</field>
+        <field name="model_id" ref="document_page.model_document_page_history"/>
+        <field name="domain_force" eval="['|', ('page_id.parent_id','=',ref('document_page_group_procedure')), ('page_id','=',ref('document_page_group_procedure'))]"/>
+        <field name="groups" eval="[(4, ref('mgmtsystem.group_mgmtsystem_viewer'))]"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="True"/>
+        <field name="perm_create" eval="True"/>
+        <field name="perm_unlink" eval="True"/>
+    </record>
+</odoo>

--- a/document_page_work_instruction/__manifest__.py
+++ b/document_page_work_instruction/__manifest__.py
@@ -17,6 +17,7 @@
         'data/document_page.xml',
 
         'views/document_page_work_instructions.xml',
+        'security/work_instruction_security.xml',
     ],
     "demo": [],
     'installable': True,

--- a/document_page_work_instruction/security/work_instruction_security.xml
+++ b/document_page_work_instruction/security/work_instruction_security.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Read/Write/Create/Unlink access in 'Management System / viewer' group
+        to 'Work instruction' documents -->
+    <record id="work_document_rule_mgmtsystem_viewer" model="ir.rule">
+        <field name="name">Work document page for viewers</field>
+        <field name="model_id" ref="document_page.model_document_page"/>
+        <field name="domain_force" eval="['|', ('parent_id','=',ref('document_page_group_work_instructions')), ('id','=',ref('document_page_group_work_instructions'))]"/>
+        <field name="groups" eval="[(4, ref('mgmtsystem.group_mgmtsystem_viewer'))]"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="True"/>
+        <field name="perm_create" eval="True"/>
+        <field name="perm_unlink" eval="True"/>
+    </record>
+
+    <record id="work_document_history_rule_mgmtsystem_viewer" model="ir.rule">
+        <field name="name">Work document page history for viewers</field>
+        <field name="model_id" ref="document_page.model_document_page_history"/>
+        <field name="domain_force" eval="['|', ('page_id.parent_id','=',ref('document_page_group_work_instructions')), ('page_id','=',ref('document_page_group_work_instructions'))]"/>
+        <field name="groups" eval="[(4, ref('mgmtsystem.group_mgmtsystem_viewer'))]"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="True"/>
+        <field name="perm_create" eval="True"/>
+        <field name="perm_unlink" eval="True"/>
+    </record>
+</odoo>

--- a/mgmtsystem/README.rst
+++ b/mgmtsystem/README.rst
@@ -51,6 +51,9 @@ Contributors
 * Savoir-faire Linux <support@savoirfairelinux.com>
 * Gervais Naoussi <gervaisnaoussi@gmail.com>
 * Eugen Don <eugen.don@don-systems.de>
+* `Tecnativa <https://www.tecnativa.com>`_:
+
+  * Ernesto Tejeda
 
 Maintainer
 ----------

--- a/mgmtsystem/__manifest__.py
+++ b/mgmtsystem/__manifest__.py
@@ -12,13 +12,14 @@
     'images': ['images/mgmtsystem.png', 'images/mgmtsystem-hover.png'],
     "depends": [
         'base',
+        'document_page',
     ],
     "data": [
         'security/mgmtsystem_security.xml',
         'security/ir.model.access.csv',
         'views/menus.xml',
         'views/mgmtsystem_system.xml',
-        'views/res_config.xml'
+        'views/res_config.xml',
     ],
     "demo": [],
     'installable': True,

--- a/mgmtsystem/security/ir.model.access.csv
+++ b/mgmtsystem/security/ir.model.access.csv
@@ -1,5 +1,10 @@
 "id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
 "access_mgmtsystem_system_user","mgmtsystem.system.user","model_mgmtsystem_system","mgmtsystem.group_mgmtsystem_user",1,0,0,0
 "access_mgmtsystem_system_viewer","mgmtsystem.system.viewer","model_mgmtsystem_system","mgmtsystem.group_mgmtsystem_viewer",1,0,0,0
+"access_document_page_mgmtsystem_viewer","document.page.mgmtsystem.viewer","document_page.model_document_page","group_mgmtsystem_viewer",1,0,0,0
+"access_document_page_history_mgmtsystem_viewer","document.page.history.mgmtsystem.viewer","document_page.model_document_page_history","group_mgmtsystem_viewer",1,0,0,0
 "access_mgmtsystem_system_auditor","mgmtsystem.system.auditor","model_mgmtsystem_system","mgmtsystem.group_mgmtsystem_auditor",1,0,0,0
+"access_document_page_mgmtsystem_auditor","document.page.mgmtsystem.auditor","document_page.model_document_page","group_mgmtsystem_auditor",1,1,1,0
+"access_document_page_history_mgmtsystem_auditor","document.page.history.mgmtsystem.auditor","document_page.model_document_page_history","group_mgmtsystem_auditor",1,1,1,0
 "access_mgmtsystem_system_manager","mgmtsystem.system.manager","model_mgmtsystem_system","mgmtsystem.group_mgmtsystem_manager",1,1,1,1
+"access_document_page_mgmtsystem_manager","document.page.mgmtsystem.manager","document_page.model_document_page","group_mgmtsystem_manager",1,1,1,1

--- a/mgmtsystem/security/mgmtsystem_security.xml
+++ b/mgmtsystem/security/mgmtsystem_security.xml
@@ -20,14 +20,6 @@
         <field name="implied_ids" eval="[(4,ref('mgmtsystem.group_mgmtsystem_viewer'))]"/>
     </record>
 
-    <record id="group_mgmtsystem_user_manager" model="res.groups">
-        <field name="name">Approving User</field>
-        <field name="comment">Module user with additional permission for approvals.</field>
-        <field name="category_id" ref="module_category_management_system"/>
-        <field name="implied_ids" eval="[(4,ref('mgmtsystem.group_mgmtsystem_user'))]"/>
-        <field name="users" eval="[(6,0,[ref('base.user_root')])]"/>
-    </record>
-
     <record id="group_mgmtsystem_auditor" model="res.groups">
         <field name="name">Auditor</field>
         <field name="comment">Module user with additional permission specific for the auditor job, such as effectiveness reviews.</field>
@@ -52,4 +44,49 @@
         <field name="domain_force">['|',('company_id','=',False),('company_id','child_of',[user.company_id.id])]</field>
     </record>
 
+    <!-- No page access by default; submodules add access to specific sections -->
+    <record id="no_document_rule_mgmtsystem_viewer" model="ir.rule">
+        <field name="name">No document page for viewers</field>
+        <field name="model_id" ref="document_page.model_document_page"/>
+        <field name="domain_force" eval="[(0, '=', 1)]"/>
+        <field name="groups" eval="[(4, ref('mgmtsystem.group_mgmtsystem_viewer'))]"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="True"/>
+        <field name="perm_create" eval="True"/>
+        <field name="perm_unlink" eval="True"/>
+    </record>
+
+    <record id="no_document_history_rule_mgmtsystem_viewer" model="ir.rule">
+        <field name="name">No document page history for viewers</field>
+        <field name="model_id" ref="document_page.model_document_page_history"/>
+        <field name="domain_force" eval="[(0, '=', 1)]"/>
+        <field name="groups" eval="[(4, ref('mgmtsystem.group_mgmtsystem_viewer'))]"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="True"/>
+        <field name="perm_create" eval="True"/>
+        <field name="perm_unlink" eval="True"/>
+    </record>
+
+    <!-- Read access in 'Knowledge / Knowledge User' group for all documents -->
+    <record id="document_page_rule_document_user_r" model="ir.rule">
+        <field name="name">All document pages (read)</field>
+        <field name="model_id" ref="document_page.model_document_page"/>
+        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="groups" eval="[(4, ref('knowledge.group_document_user'))]"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="True"/>
+        <field name="perm_create" eval="True"/>
+        <field name="perm_unlink" eval="True"/>
+    </record>
+
+    <record id="document_page_history_rule_document_user_r" model="ir.rule">
+        <field name="name">All document pages history (read)</field>
+        <field name="model_id" ref="document_page.model_document_page_history"/>
+        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="groups" eval="[(4, ref('knowledge.group_document_user'))]"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="True"/>
+        <field name="perm_create" eval="True"/>
+        <field name="perm_unlink" eval="True"/>
+    </record>
 </odoo>

--- a/mgmtsystem_manual/__manifest__.py
+++ b/mgmtsystem_manual/__manifest__.py
@@ -17,6 +17,7 @@
         'data/mgmtsystem_manual.xml',
         'views/mgmtsystem_manual.xml',
         'views/document_page.xml',
+        'security/manual_security.xml',
     ],
     "demo": [],
     'installable': True,

--- a/mgmtsystem_manual/security/manual_security.xml
+++ b/mgmtsystem_manual/security/manual_security.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Read/Write/Create/Unlink access in 'Management System / viewer' group
+        to 'Manual' documents -->
+    <record id="manual_document_rule_mgmtsystem_viewer" model="ir.rule">
+        <field name="name">Manual document page for viewers</field>
+        <field name="model_id" ref="document_page.model_document_page"/>
+        <field name="domain_force" eval="['|', ('parent_id','ilike', 'manual'), ('name','ilike', 'manual')]"/>
+        <field name="groups" eval="[(4, ref('mgmtsystem.group_mgmtsystem_viewer'))]"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="True"/>
+        <field name="perm_create" eval="True"/>
+        <field name="perm_unlink" eval="True"/>
+    </record>
+
+    <record id="manual_document_history_rule_mgmtsystem_viewer" model="ir.rule">
+        <field name="name">Manual document page for viewers</field>
+        <field name="model_id" ref="document_page.model_document_page_history"/>
+        <field name="domain_force" eval="['|', ('page_id.parent_id','ilike', 'manual'), ('page_id.name','ilike', 'manual')]"/>
+        <field name="groups" eval="[(4, ref('mgmtsystem.group_mgmtsystem_viewer'))]"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="True"/>
+        <field name="perm_create" eval="True"/>
+        <field name="perm_unlink" eval="True"/>
+    </record>
+</odoo>


### PR DESCRIPTION
It gives right access to document.page of management system to the users of the 'Management System' groups.
With this, it's not necessary for the users of the Management System to be added to a Knowledge group in order to have access to their document.page, since adding them to a Knowledge group implies that they see all the document.pages and also everything under the Knowledge menu

Cc @Tecnativa