### PR TITLE
[FIX] mgmtsystem_audit: number_of_nonconformities

### DIFF
--- a/mgmtsystem_audit/models/mgmtsystem_audit.py
+++ b/mgmtsystem_audit/models/mgmtsystem_audit.py
@@ -91,7 +91,7 @@ class MgmtsystemAudit(models.Model):
     def _compute_number_of_nonconformities(self):
         """Count number of nonconformities."""
         for audit in self:
-            audit.number_of_nonconformities = len(self.nonconformity_ids)
+            audit.number_of_nonconformities = len(audit.nonconformity_ids)
 
     @api.depends("imp_opp_ids")
     def _compute_number_of_improvement_opportunities(self):


### PR DESCRIPTION
Since iterating over self, nonconformities should be calculated over audit