### PR TITLE
[11.0] [FIX] fields related should be readonly True

### DIFF
--- a/mgmtsystem_nonconformity/models/mgmtsystem_nonconformity.py
+++ b/mgmtsystem_nonconformity/models/mgmtsystem_nonconformity.py
@@ -95,6 +95,7 @@ class MgmtsystemNonconformity(models.Model):
         default=_default_stage, group_expand='_stage_groups')
     state = fields.Selection(
         related='stage_id.state',
+        readonly=True,
         store=True,
     )
     kanban_state = fields.Selection(


### PR DESCRIPTION
Only impact in V11.

If you are user with the low level of rights "Viewer" group
Try to create an nonconformity record, fill the fields an the try to save.
An error occurs related to stage model.

The problem is with this related fields that need to be read-only.

The desired behaviour is this user be able to create your own non conformity records.