### PR TITLE
[FIX] Fix automatic install of work instruction template

### DIFF
--- a/mgmtsystem/models/res_config.py
+++ b/mgmtsystem/models/res_config.py
@@ -102,3 +102,8 @@ class MgmtsystemConfigSettings(models.TransientModel):
         help="Provide document approval and history. \n"
         "- This installs the module document_page_approval.",
     )
+    module_document_page_work_instruction = fields.Boolean(
+        "Work Instructions",
+        help="Provide Work Instructions category.\n"
+        "- This installs the module document_page_work_instruction.",
+    )

--- a/mgmtsystem/views/res_config.xml
+++ b/mgmtsystem/views/res_config.xml
@@ -243,6 +243,18 @@
                             </div>
                         </div>
 
+                        <div class="col-xs-12 col-md-6 o_setting_box">
+                            <div class="o_setting_left_pane">
+                                <field name="module_document_page_work_instruction" class="oe_inline"/>
+                            </div>
+                            <div class="o_setting_right_pane">
+                                <label for="module_document_page_work_instruction"/>
+                                <div class="text-muted">
+                                    Provide a Work Instructions documentation category and template
+                                </div>
+                            </div>
+                        </div>
+
                     </div>
 
                 </div>


### PR DESCRIPTION
This just adds document_page_work_instruction as dependency for document_page_procedure to get it automatically installed as in 10.0