### PR TITLE
Fix odoo warning with duplicate field string

### DIFF
--- a/mgmtsystem/models/res_config.py
+++ b/mgmtsystem/models/res_config.py
@@ -5,13 +5,13 @@ from odoo import fields, models
 
 
 class MgmtsystemConfigSettings(models.TransientModel):
-    """This class is useed to activate management system Applications."""
+    """This class is used to activate management system Applications."""
 
     _inherit = "res.config.settings"
 
     # Systems
     module_mgmtsystem_quality = fields.Boolean(
-        "Quality",
+        "Quality Tools",
         help="Provide quality management tools.\n"
         "- This installs the module mgmtsystem_quality.",
     )


### PR DESCRIPTION
The enterprise module "quality_control" adds a field with the string
"Quality" in "res.config.settings", so does mgmtsystem.

Which results in a lot of warnings at the loading of the modules:

Two fields (module_quality_control, module_mgmtsystem_quality) of res.config.settings() have the same label: Quality.

I propose a slight change to the string to avoid this.