### PR TITLE
mgmtsystem_claim: Claim statusbar not clickable

### DIFF
--- a/mgmtsystem_claim/views/mgmtsystem_claim.xml
+++ b/mgmtsystem_claim/views/mgmtsystem_claim.xml
@@ -32,7 +32,11 @@
             <field name="arch" type="xml">
                 <form string="Claim">
                     <header>
-                        <field name="stage_id" widget="statusbar" clickable="True"/>
+                        <field
+                            name="stage_id"
+                            widget="statusbar"
+                            options="{'clickable': 1}"
+                        />
                     </header>
                     <sheet string="Claims">
                         <group>


### PR DESCRIPTION
The Claim form's statusbar is intended to be clickable, but Odoo 13 is apparently no longer compatible with `clickable="True"`. Instead, either `clickable="1"` or `options="{'clickable': 1}"` must be used. Odoo core code uses the latter, so the Claim form has been updated to match core convention.