### PR TITLE
Send mail with sudo on action create

### DIFF
--- a/mgmtsystem_action/models/mgmtsystem_action.py
+++ b/mgmtsystem_action/models/mgmtsystem_action.py
@@ -139,7 +139,7 @@ class MgmtsystemAction(models.Model):
     def send_mail_for_action(self, action, force_send=True):
         template = self.env.ref(
             'mgmtsystem_action.email_template_new_action_reminder')
-        template.send_mail(action.id, force_send=force_send)
+        template.sudo().send_mail(action.id, force_send=force_send)
         return True
 
     def get_action_url(self):


### PR DESCRIPTION
Mail should be always sent when creating and action, regardless of security rules since this is a system mail