### PR TITLE
mgmtsystem_action: Action statusbar not clickable

### DIFF
--- a/mgmtsystem_action/views/mgmtsystem_action.xml
+++ b/mgmtsystem_action/views/mgmtsystem_action.xml
@@ -68,7 +68,7 @@
             <field name="arch" type="xml">
                 <form string="Action">
                     <header>
-                        <field name="stage_id" widget="statusbar" clickable="True"/>
+                        <field name="stage_id" widget="statusbar" options="{'clickable': 1}"/>
                     </header>
                     <sheet string="Action">
                         <div class="oe_title" modifiers="{}">


### PR DESCRIPTION
The Action form's statusbar is intended to be clickable, but Odoo 13 is apparently no longer compatible with clickable="True". Instead, either clickable="1" or options="{'clickable': 1}" must be used. Odoo core code uses the latter, so the Claim form has been updated to match core convention.