### PR TITLE
mgmtsystem_nonconformity: Non conformity statusbar not clickable

### DIFF
--- a/mgmtsystem_nonconformity/__manifest__.py
+++ b/mgmtsystem_nonconformity/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "Management System - Nonconformity",
-    "version": "13.0.1.1.0",
+    "version": "13.0.1.1.1",
     "author": "Savoir-faire Linux, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/management-system",
     "license": "AGPL-3",

--- a/mgmtsystem_nonconformity/views/mgmtsystem_nonconformity.xml
+++ b/mgmtsystem_nonconformity/views/mgmtsystem_nonconformity.xml
@@ -112,7 +112,7 @@
       <field name="arch" type="xml">
         <form string="Non-Conformity" version="7.0">
           <header>
-            <field name="stage_id" widget="statusbar" clickable="True" />
+            <field name="stage_id" widget="statusbar" options="{'clickable': 1}" />
             <field name="state" invisible="True" />
           </header>
           <sheet string="Non-Conformity">


### PR DESCRIPTION
The Non conformity form's statusbar is intended to be clickable, but Odoo 13 is apparently no longer compatible with clickable="True". Instead, either clickable="1" or options="{'clickable': 1}" must be used. Odoo core code uses the latter, so the Claim form has been updated to match core convention.