### PR TITLE
[12.0][IMP] mgmtsystem_nonconformity: view changes

### DIFF
--- a/mgmtsystem_nonconformity/views/mgmtsystem_nonconformity.xml
+++ b/mgmtsystem_nonconformity/views/mgmtsystem_nonconformity.xml
@@ -15,6 +15,7 @@
         <field name="create_date"/>
         <field name="partner_id"/>
         <field name="description"/>
+        <field name="origin_ids" widget="many2many_tags"/>
         <field name="user_id"/>
         <field name="responsible_user_id"/>
         <field name="manager_user_id"/>
@@ -39,6 +40,7 @@
           <field name="ref"/>
           <field name="create_date"/>
           <field name="user_id" string="User" domain="['|','|',('user_id','=',uid),('responsible_user_id','=',uid),('manager_user_id','=',uid)]" />
+          <field name="origin_ids"/>
           <field name="system_id"/>
           <field name="company_id" groups="base.group_multi_company"/>
         </group>
@@ -94,6 +96,7 @@
                                 <div>
                                     <strong><field name="ref"/> - <field name="name"/></strong>
                                 </div>
+                                <field name="origin_ids" widget="many2many_tags"/>
                                 <div>
                                     <br/>
                                 </div>

--- a/mgmtsystem_nonconformity/views/mgmtsystem_nonconformity.xml
+++ b/mgmtsystem_nonconformity/views/mgmtsystem_nonconformity.xml
@@ -158,7 +158,7 @@
                 <field name="procedure_ids" attrs="{'readonly':[('state','not in',['draft','analysis'])]}" domain="[('parent_id','in',('Procedure','Environmental Aspect','Manuals'))]"/>
               </page>
 
-              <page string="Causes and Analysis" attrs="{'invisible':[('state','in',['draft','cancel'])]}">
+              <page string="Causes and Analysis" attrs="{'invisible':[('state','in',['draft'])]}">
                 <separator string="Analysis"/>
                 <field name="analysis" attrs="{'readonly':[('state','not in',['analysis'])]}"/>
 
@@ -181,7 +181,7 @@
                 </group>
               </page>
 
-              <page string="Actions" attrs="{'invisible':[('state','in',['draft','analysis','cancel'])]}">
+              <page string="Actions" attrs="{'invisible':[('state','in',['draft','analysis'])]}">
                 <separator string="Action Plan"/>
                 <field name="action_ids" attrs="{'readonly':[('state','not in',['pending'])]}"/>
 


### PR DESCRIPTION
This PR contains 2 commits:
- The first commit adds the field `origin_ids` to the tree and kanban view and also adds it as a filter.
- The second commit makes all tabs/pages in the nonconformity's form visible when it is cancelled. Maybe the nonconformity was cancelled in a very late stage and you want to have the information visible.

@etobella 