### PR TITLE
[ADD] Add chatter to mgmtsystem.review

### DIFF
--- a/mgmtsystem_review/models/mgmtsystem_review.py
+++ b/mgmtsystem_review/models/mgmtsystem_review.py
@@ -6,6 +6,7 @@ from odoo import api, fields, models
 
 class MgmtsystemReview(models.Model):
     _name = "mgmtsystem.review"
+    _inherit = ["mail.thread", "mail.activity.mixin"]
     _description = "Review"
 
     name = fields.Char("Name", size=50, required=True)

--- a/mgmtsystem_review/views/mgmtsystem_review.xml
+++ b/mgmtsystem_review/views/mgmtsystem_review.xml
@@ -158,6 +158,11 @@
                         </page>
                     </notebook>
                 </sheet>
+                <div class="oe_chatter">
+                    <field name="message_follower_ids" widget="mail_followers" />
+                    <field name="activity_ids" widget="mail_activity" />
+                    <field name="message_ids" widget="mail_thread" />
+                </div>
             </form>
         </field>
     </record>


### PR DESCRIPTION
This adds the chatter to Reviews. The model mgmtsystem.review is the only one in the Management System that doesn't have chatter integrated. Actions, Non-conformities, Audits, Manuals, Forms, Flow Diagrams etc all have it already.