### PR TITLE
[14.0][FIX] mgmtsystem_action: fix warning + structure

### DIFF
--- a/mgmtsystem_action/views/mgmtsystem_action.xml
+++ b/mgmtsystem_action/views/mgmtsystem_action.xml
@@ -258,28 +258,28 @@
                                         groups="base.group_user"
                                     >
                                             <a
-                                            class="dropdown-toggle btn"
-                                            data-toggle="dropdown"
-                                            href="#"
+                                            class="dropdown-toggle o-no-caret btn"
                                             role="button"
+                                            data-toggle="dropdown"
+                                            data-display="static"
+                                            href="#"
+                                            aria-label="Dropdown menu"
+                                            title="Dropdown menu"
                                         >
-                                                <span
-                                                class="fa fa-ellipsis-v"
-                                                aria-hidden="true"
-                                            />
+                                                <span class="fa fa-ellipsis-v" />
                                             </a>
-                                            <ul
-                                            class="dropdown-menu"
-                                            role="menu"
-                                            aria-labelledby="dLabel"
-                                        >
-                                                <li t-if="widget.editable"><a
+                                            <div class="dropdown-menu" role="menu">
+                                                <t t-if="widget.editable"><a
+                                                    role="menuitem"
                                                     type="edit"
-                                                >Edit Task</a></li>
-                                                <li t-if="widget.deletable"><a
+                                                    class="dropdown-item"
+                                                >Edit Task</a></t>
+                                                <t t-if="widget.deletable"><a
+                                                    role="menuitem"
                                                     type="delete"
-                                                >Delete</a></li>
-                                            </ul>
+                                                    class="dropdown-item"
+                                                >Delete</a></t>
+                                            </div>
                                         </div>
                                     </div>
 


### PR DESCRIPTION
Somehow the bot merged https://github.com/OCA/management-system/pull/382 despite the runbot warning: `A <span> with fa class (fa fa-ellipsis-v) must have title in its tag, parents, descendants or have text`.

So the same warning is now raised in new merges attempts, such as https://github.com/OCA/management-system/pull/370 and seems to block them.

This PR fixes it and also takes the opportunity to [update the dropdown structure](https://github.com/odoo/odoo/commit/1c1c0897e8eca607c7f1b96b68a06c026c543e6a).
