### PR TITLE
[14.0][FIX] mgmtsystem_manual: Set correct domain and context in action manual (auto-fill manual category)

### DIFF
--- a/mgmtsystem_manual/views/mgmtsystem_manual.xml
+++ b/mgmtsystem_manual/views/mgmtsystem_manual.xml
@@ -7,7 +7,8 @@
         <field name="view_id" ref="document_page.view_wiki_tree" />
         <field name="search_view_id" ref="document_page.view_wiki_filter" />
         <field name="help">Manuals of your management systems.</field>
-        <field name="domain" eval="[('parent_id','ilike', 'manual')]" />
+        <field name="domain" eval="[('parent_id','=',ref('manuals'))]" />
+        <field name="context" eval="{'default_parent_id': ref('manuals')}" />
     </record>
     <record id="action_manuals_tree" model="ir.actions.act_window.view">
         <field name="sequence" eval="0" />


### PR DESCRIPTION
FW from 13.0: https://github.com/OCA/management-system/pull/386

Set correct domain and context in action manual (auto-fill manual category).

Please @joao-p-marques and @pedrobaeza can you review it?

@Tecnativa TT32895