### PR TITLE
[13.0][IMP] mgmtsystem_nonconformity: enabling to create non-conformities from different models

### DIFF
--- a/mgmtsystem_nonconformity/models/__init__.py
+++ b/mgmtsystem_nonconformity/models/__init__.py
@@ -8,3 +8,4 @@ from . import mgmtsystem_nonconformity_origin
 from . import mgmtsystem_nonconformity_severity
 from . import mgmtsystem_nonconformity
 from . import mgmtsystem_action
+from . import mgmtsystem_nonconformity_abstract

--- a/mgmtsystem_nonconformity/models/mgmtsystem_nonconformity.py
+++ b/mgmtsystem_nonconformity/models/mgmtsystem_nonconformity.py
@@ -140,6 +140,8 @@ class MgmtsystemNonconformity(models.Model):
     company_id = fields.Many2one(
         "res.company", "Company", default=lambda self: self.env.company
     )
+    res_model = fields.Char()
+    res_id = fields.Integer(index=True)
 
     def _get_all_actions(self):
         self.ensure_one()

--- a/mgmtsystem_nonconformity/models/mgmtsystem_nonconformity_abstract.py
+++ b/mgmtsystem_nonconformity/models/mgmtsystem_nonconformity_abstract.py
@@ -1,0 +1,40 @@
+# Copyright (C) 2010 Savoir-faire Linux (<http://www.savoirfairelinux.com>).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+
+from odoo import api, fields, models
+
+
+class MgmtsystemNonconformityAbstract(models.AbstractModel):
+
+    _name = "mgmtsystem.nonconformity.abstract"
+    _description = "Nonconformity Abstract"
+
+    non_conformity_ids = fields.One2many(
+        "mgmtsystem.nonconformity",
+        inverse_name="res_id",
+        domain=lambda r: [("res_model", "=", r._name)],
+        readonly=True,
+    )
+
+    non_conformity_count = fields.Integer(compute="_compute_non_conformity_count")
+
+    @api.depends("non_conformity_ids")
+    def _compute_non_conformity_count(self):
+        self.ensure_one()
+        self.non_conformity_count = len(self.non_conformity_ids)
+
+    def _get_non_conformities_domain(self):
+        return [("res_model", "=", self._name), ("res_id", "=", self.id)]
+
+    def _get_non_conformities_context(self):
+        return {}
+
+    def action_view_non_conformities(self):
+        self.ensure_one()
+        action = self.env.ref(
+            "mgmtsystem_nonconformity.open_mgmtsystem_nonconformity_list"
+        ).read()[0]
+        action["domain"] = self._get_non_conformities_domain()
+        action["context"] = self._get_non_conformities_context()
+        return action


### PR DESCRIPTION
This PR adds the option to relate non_conformities with any other module. For example, if we want to relate a maintenance request with a non_conformity. 