### PR TITLE
[16.0] [IMP] mgmtsystem_nonconformity: Show non conformities on all records

### DIFF
--- a/mgmtsystem_nonconformity/__manifest__.py
+++ b/mgmtsystem_nonconformity/__manifest__.py
@@ -30,5 +30,11 @@
         "demo/mgmtsystem_nonconformity_cause.xml",
         "demo/mgmtsystem_nonconformity.xml",
     ],
+    "assets": {
+        "web.assets_backend": [
+            "mgmtsystem_nonconformity/static/src/**/*.xml",
+            "mgmtsystem_nonconformity/static/src/**/*.js",
+        ],
+    },
     "installable": True,
 }

--- a/mgmtsystem_nonconformity/models/mgmtsystem_nonconformity.py
+++ b/mgmtsystem_nonconformity/models/mgmtsystem_nonconformity.py
@@ -43,7 +43,9 @@ class MgmtsystemNonconformity(models.Model):
     closing_date = fields.Datetime(readonly=True)
 
     partner_id = fields.Many2one("res.partner", "Partner", required=True)
-    reference = fields.Char("Related to")
+    reference = fields.Char(
+        "Related to", default=lambda self: self._default_reference()
+    )
     responsible_user_id = fields.Many2one(
         "res.users", "Responsible", required=True, tracking=True
     )
@@ -137,8 +139,19 @@ class MgmtsystemNonconformity(models.Model):
     company_id = fields.Many2one(
         "res.company", "Company", default=lambda self: self.env.company
     )
-    res_model = fields.Char()
+    res_model = fields.Char(index=True)
     res_id = fields.Integer(index=True)
+
+    @api.model
+    def _default_reference(self):
+        if self.env.context.get("active_model") and self.env.context.get("active_id"):
+            return (
+                self.env[self.env.context["active_model"]]
+                .browse(self.env.context.get("active_id"))
+                .exists()
+                .display_name
+            )
+        return ""
 
     def _get_all_actions(self):
         self.ensure_one()

--- a/mgmtsystem_nonconformity/models/mgmtsystem_nonconformity_abstract.py
+++ b/mgmtsystem_nonconformity/models/mgmtsystem_nonconformity_abstract.py
@@ -1,12 +1,14 @@
 # Copyright (C) 2010 Savoir-faire Linux (<http://www.savoirfairelinux.com>).
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from lxml import etree
 
 from odoo import api, fields, models
+from odoo.tools.misc import frozendict
 
 
 class MgmtsystemNonconformityAbstract(models.AbstractModel):
-
+    # TODO: Remove this on 17.0 and move everything on mail.thread
     _name = "mgmtsystem.nonconformity.abstract"
     _description = "Nonconformity Abstract"
 
@@ -38,3 +40,51 @@ class MgmtsystemNonconformityAbstract(models.AbstractModel):
         action["domain"] = self._get_non_conformities_domain()
         action["context"] = self._get_non_conformities_context()
         return action
+
+
+class MailThread(models.AbstractModel):
+    _name = "mail.thread"
+    _inherit = ["mail.thread", "mgmtsystem.nonconformity.abstract"]
+
+    @api.model
+    def get_view(self, view_id=None, view_type="form", **options):
+        res = super().get_view(view_id=view_id, view_type=view_type, **options)
+        if view_type == "form" and self.env.user.has_group(
+            "mgmtsystem.group_mgmtsystem_viewer"
+        ):
+            View = self.env["ir.ui.view"]
+            if view_id and res.get("base_model", self._name) != self._name:
+                View = View.with_context(base_model_name=res["base_model"])
+            doc = etree.XML(res["arch"])
+
+            # We need to copy, because it is a frozen dict
+            all_models = res["models"].copy()
+            for node in doc.xpath("/form/div[hasclass('oe_chatter')]"):
+                # _add_tier_validation_label process
+                new_node = etree.fromstring(
+                    "<field name='non_conformity_count' invisible='1'/>"
+                )
+                new_arch, new_models = View.postprocess_and_fields(new_node, self._name)
+                new_node = etree.fromstring(new_arch)
+                for model in list(filter(lambda x: x not in all_models, new_models)):
+                    if model not in res["models"]:
+                        all_models[model] = new_models[model]
+                    else:
+                        all_models[model] = res["models"][model]
+                node.addprevious(new_node)
+            res["arch"] = etree.tostring(doc)
+            res["models"] = frozendict(all_models)
+        return res
+
+    @api.model
+    def _get_view_fields(self, view_type, models):
+        """
+        We need to add this in order to fix the usage of form opening from
+        trees inside a form
+        """
+        result = super()._get_view_fields(view_type, models)
+        if view_type == "form" and self.env.user.has_group(
+            "mgmtsystem.group_mgmtsystem_viewer"
+        ):
+            result[self._name].add("non_conformity_count")
+        return result

--- a/mgmtsystem_nonconformity/static/src/components/chatter_topbar/chatter_topbar.esm.js
+++ b/mgmtsystem_nonconformity/static/src/components/chatter_topbar/chatter_topbar.esm.js
@@ -1,0 +1,26 @@
+/** @odoo-module **/
+
+import {registerPatch} from "@mail/model/model_core";
+
+registerPatch({
+    name: "Chatter",
+    recordMethods: {
+        async onClickShowNonConformities() {
+            if (this.isTemporary) {
+                const saved = await this.doSaveRecord();
+                if (!saved) {
+                    return;
+                }
+            }
+            this.env.services.action.doAction(
+                "mgmtsystem_nonconformity.open_mgmtsystem_nonconformity_thread_list",
+                {
+                    additionalContext: {
+                        active_id: this.thread.id,
+                        active_model: this.thread.model,
+                    },
+                }
+            );
+        },
+    },
+});

--- a/mgmtsystem_nonconformity/static/src/components/chatter_topbar/chatter_topbar.xml
+++ b/mgmtsystem_nonconformity/static/src/components/chatter_topbar/chatter_topbar.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+
+    <t
+        t-name="mgmtsystem_nonconformity.ChatterTopbar"
+        t-inherit="mail.ChatterTopbar"
+        t-inherit-mode="extension"
+        owl="1"
+    >
+        <xpath
+            expr="//button[hasclass('o_ChatterTopbar_buttonToggleAttachments')]"
+            position="after"
+        >
+            <button
+                class="o_ChatterTopbar_button o_ChatterTopbar_buttonNonConformities btn btn-light btn-primary"
+                type="button"
+                t-att-disabled="!chatterTopbar.chatter.isTemporary and !chatterTopbar.chatter.hasWriteAccess"
+                t-on-click="() => this.chatterTopbar.chatter.onClickShowNonConformities()"
+                t-if="chatterTopbar.chatter.webRecord.data.non_conformity_count !== undefined"
+            >
+                <i
+                    class="fa fa-exclamation-triangle fa-lg me-1"
+                    role="img"
+                    aria-label="Non conformities"
+                />
+                <span
+                    class="o_ChatterTopbar_buttonCount o_ChatterTopbar_buttonNonConformitiesCount"
+                    t-esc="chatterTopbar.chatter.webRecord.data.non_conformity_count"
+                />
+            </button>
+        </xpath>
+    </t>
+</templates>

--- a/mgmtsystem_nonconformity/views/mgmtsystem_nonconformity.xml
+++ b/mgmtsystem_nonconformity/views/mgmtsystem_nonconformity.xml
@@ -392,6 +392,23 @@
         <field name="context">{"search_default_user_id":uid}</field>
     </record>
 
+    <record
+        model="ir.actions.act_window"
+        id="open_mgmtsystem_nonconformity_thread_list"
+    >
+        <field name="name">Nonconformities</field>
+        <field name="res_model">mgmtsystem.nonconformity</field>
+        <field name="view_mode">kanban,tree,form</field>
+        <field
+            name="domain"
+        >[('res_id', '=', active_id), ('res_model', '=', active_model)]</field>
+        <field name="view_id" ref="view_mgmtsystem_nonconformity_kanban" />
+        <field name="search_view_id" ref="view_mgmtsystem_nonconformity_filter" />
+        <field
+            name="context"
+        >{"search_default_user_id":uid, "default_res_model": active_model, "default_res_id": active_id}</field>
+    </record>
+
     <menuitem
         id="menu_open_nonconformity"
         name="Nonconformities"


### PR DESCRIPTION
Before this change, we needed to add patches everywhere. With this change we just need to click on the non-conformity button on the record chatter. It does not appear if you don't have access to mgmtsystem.

![Captura desde 2024-01-18 21-47-33](https://github.com/OCA/management-system/assets/28590170/a10470be-4ca6-40ac-b7ba-d23e99d18886)
