### PR TITLE
[16.0][FIX] mgmtsystem_nonconformity: Fix origin and cause form views

### DIFF
--- a/mgmtsystem_nonconformity/views/mgmtsystem_cause.xml
+++ b/mgmtsystem_nonconformity/views/mgmtsystem_cause.xml
@@ -13,7 +13,7 @@
             <field name="sequence" />
             <field name="parent_id" />
             <field name="ref_code" />
-            <field name="description" colspan="4" />
+            <field name="description" />
           </group>
         </form>
       </field>

--- a/mgmtsystem_nonconformity/views/mgmtsystem_origin.xml
+++ b/mgmtsystem_nonconformity/views/mgmtsystem_origin.xml
@@ -22,7 +22,7 @@
               <field name="sequence" />
               <field name="parent_id" />
               <field name="ref_code" />
-              <field name="description" colspan="4" />
+              <field name="description" />
             </group>
           </sheet>
         </form>


### PR DESCRIPTION
The origin and cause form views do not render correctly because the description field in both forms uses colspan="4". Removing the colspan attribute so that the default value is used fixes the problem.

Origin form view before:
![image](https://github.com/OCA/management-system/assets/111332892/5b916a08-3dee-4441-b85a-755935df89b7)
Origin form view fixed:
![image](https://github.com/OCA/management-system/assets/111332892/67e47534-84c0-4b5b-8f63-e36f6c188e48)

Cause form view before:
![image](https://github.com/OCA/management-system/assets/111332892/8d612707-f379-4295-b4fc-214aa5d078be)
Cause form view fixed:
![image](https://github.com/OCA/management-system/assets/111332892/4f7a441d-4f4d-4c0e-8725-181419ecee38)
