### PR TITLE
[FIX] mgmtsystem_evaluation: support model_field_char option in reference widget to avoid access to ir.model

### DIFF
--- a/mgmtsystem_evaluation/__manifest__.py
+++ b/mgmtsystem_evaluation/__manifest__.py
@@ -20,4 +20,9 @@
         "data/cron.xml",
     ],
     "demo": ["demo/demo.xml"],
+    "assets": {
+        "web.assets_backend": [
+            "mgmtsystem_evaluation/**/*",
+        ],
+    },
 }

--- a/mgmtsystem_evaluation/models/mgmtsystem_evaluation.py
+++ b/mgmtsystem_evaluation/models/mgmtsystem_evaluation.py
@@ -26,7 +26,10 @@ class MgmtsystemEvaluation(models.Model):
         string="Model technical name",
     )
     model_id = fields.Many2one(
-        "ir.model", compute="_compute_template_fields", store=True, readonly=False
+        "ir.model",
+        compute="_compute_template_fields",
+        store=True,
+        readonly=False,
     )
     res_id = fields.Many2oneReference(index=True, model_field="model")
     user_id = fields.Many2one("res.users", readonly=True, copy=False)

--- a/mgmtsystem_evaluation/models/mgmtsystem_evaluation.py
+++ b/mgmtsystem_evaluation/models/mgmtsystem_evaluation.py
@@ -111,7 +111,11 @@ class MgmtsystemEvaluation(models.Model):
 
     @api.model
     def _get_ref_selection(self):
-        models = self.env["ir.model"].sudo().search([])
+        models = (
+            self.env["ir.model"]
+            .sudo()
+            .search([("is_mgmtsystem_evaluation", "=", True)])
+        )
         return [(model.model, model.name) for model in models]
 
     @api.depends("template_id", "res_id", "model")
@@ -129,16 +133,15 @@ class MgmtsystemEvaluation(models.Model):
     @api.depends("template_id")
     def _compute_template_fields(self):
         for record in self:
-            if record.template_id and (
-                not record.model or record.template_id.model != record.model
-            ):
+            template = record.template_id
+            if template and (not record.model or template.model != record.model):
                 record.res_id = False
-                record.model = record.template_id.model
-                record.model_id = record.template_id.model_id
+                record.model = template.model
+                record.model_id = template.model_id
             if not record.feedback:
-                record.feedback = record.template_id.feedback
+                record.feedback = template.feedback
             if not record.note:
-                record.note = record.template_id.note
+                record.note = template.note
 
     @api.depends("template_id")
     def _compute_name(self):

--- a/mgmtsystem_evaluation/models/mgmtsystem_evaluation.py
+++ b/mgmtsystem_evaluation/models/mgmtsystem_evaluation.py
@@ -19,7 +19,11 @@ class MgmtsystemEvaluation(models.Model):
         states={"draft": [("readonly", False)]},
     )
     model = fields.Char(
-        index=True, compute="_compute_template_fields", store=True, readonly=False
+        index=True,
+        compute="_compute_template_fields",
+        store=True,
+        readonly=False,
+        string="Model technical name",
     )
     model_id = fields.Many2one(
         "ir.model", compute="_compute_template_fields", store=True, readonly=False

--- a/mgmtsystem_evaluation/models/mgmtsystem_evaluation_template.py
+++ b/mgmtsystem_evaluation/models/mgmtsystem_evaluation_template.py
@@ -28,12 +28,8 @@ class MgmtsytemEvaluationTemplate(models.Model):
         string="Activity for user",
         domain=lambda self: [
             "|",
-            ("res_model_id", "=", False),
-            (
-                "res_model_id",
-                "=",
-                self.env["ir.model"]._get("mgmtsystem.evaluation").id,
-            ),
+            ("res_model", "=", False),
+            ("res_model", "=", "mgmtsystem.evaluation"),
         ],
         ondelete="set null",
         help="""Automatically schedule this activity to the user
@@ -44,12 +40,8 @@ class MgmtsytemEvaluationTemplate(models.Model):
         string="Activity for manager",
         domain=lambda self: [
             "|",
-            ("res_model_id", "=", False),
-            (
-                "res_model_id",
-                "=",
-                self.env["ir.model"]._get("mgmtsystem.evaluation").id,
-            ),
+            ("res_model", "=", False),
+            ("res_model", "=", "mgmtsystem.evaluation"),
         ],
         ondelete="set null",
         help="""Automatically schedule this activity to the Manager

--- a/mgmtsystem_evaluation/static/src/js/basic_model.esm.js
+++ b/mgmtsystem_evaluation/static/src/js/basic_model.esm.js
@@ -1,0 +1,44 @@
+/** @odoo-module **/
+
+import BasicModel from "web.BasicModel";
+
+BasicModel.include({
+    /**
+     * Extend `_fetchModelFieldReference` to support `model_field_char`
+     */
+    _fetchModelFieldReference: async function (record, fieldName, fieldInfo) {
+        if (fieldInfo.options.model_field) {
+            // Call the original method if `model_field` is defined
+            return this._super.apply(this, arguments);
+        } else if (fieldInfo.options.model_field_char) {
+            const modelFieldChar = fieldInfo.options.model_field_char;
+            const modelCharValue =
+                (record._changes && record._changes[modelFieldChar]) ||
+                record.data[modelFieldChar];
+
+            if (modelCharValue) {
+                return {
+                    modelName: modelCharValue,
+                    hasChanged: true,
+                };
+            }
+
+            return Promise.resolve();
+        }
+    },
+
+    /**
+     * Extend `_fetchSpecialReference` to also consider `model_field_char`
+     */
+    _fetchSpecialReference: function (record, fieldName, fieldInfo) {
+        const field = record.fields[fieldName];
+        if (field.type === "char") {
+            return Promise.resolve(this._fetchReference(record, fieldName));
+        } else if (fieldInfo.options.model_field) {
+            return this._fetchModelFieldReference(record, fieldName, fieldInfo);
+        } else if (fieldInfo.options.model_field_char) {
+            return this._fetchModelFieldReference(record, fieldName, fieldInfo);
+        }
+        return Promise.resolve();
+    },
+});

--- a/mgmtsystem_evaluation/views/mgmtsystem_evaluation.xml
+++ b/mgmtsystem_evaluation/views/mgmtsystem_evaluation.xml
@@ -68,7 +68,7 @@
                         <field name="res_id" invisible="1" />
                         <field
                             name="resource"
-                            options="{'hide_model': 1, 'model_field': 'model_id'}"
+                            options="{'hide_model': 1, 'model_field_char': 'model'}"
                             attrs="{'invisible': [('template_id', '=', False), ('model_id', '=', False)]}"
                         />
                         <field

--- a/mgmtsystem_evaluation/views/mgmtsystem_evaluation_template.xml
+++ b/mgmtsystem_evaluation/views/mgmtsystem_evaluation_template.xml
@@ -47,7 +47,6 @@
                         </page>
                     </notebook>
                 </sheet>
-                <div class="oe_chatter" />
             </form>
         </field>
     </record>


### PR DESCRIPTION
fixing:

- AttributeError: 'mgmtsystem.evaluation.template' object has no attribute '_get_mail_thread_data'

- ValueError: Invalid field mail.activity.type.res_model_id in leaf ('res_model_id', '=', 421)

- reference field configured with model_field fails to render due to access denied errors when trying to read ir.model -> _fetchModelFieldReference using BasicModel.include, and add support for model_field_char as a fallback.

@etobella 