### PR TITLE
[16.0][FIX]mgmtsystem_evaluation: fixed model string to avoid 'same label' warnings

### DIFF
--- a/mgmtsystem_action_efficacy/models/mgmtsystem_action.py
+++ b/mgmtsystem_action_efficacy/models/mgmtsystem_action.py
@@ -18,13 +18,13 @@ class MgmtsystemAction(models.Model):
     efficacy_value = fields.Integer(
         "Rating",
         help="0:not effective | 50:efficacy not complete | 100: effective",
-        track_visibility=True,
+        tracking=True,
     )
     # user in charge of evaluation
     efficacy_user_id = fields.Many2one(
         "res.users",
         "Inspector",
-        track_visibility=True,
+        tracking=True,
     )
     # notes on the efficacy
     efficacy_description = fields.Text("Notes")

--- a/mgmtsystem_evaluation/models/mgmtsystem_evaluation.py
+++ b/mgmtsystem_evaluation/models/mgmtsystem_evaluation.py
@@ -19,7 +19,11 @@ class MgmtsystemEvaluation(models.Model):
         states={"draft": [("readonly", False)]},
     )
     model = fields.Char(
-        index=True, compute="_compute_template_fields", store=True, readonly=False
+        index=True,
+        compute="_compute_template_fields",
+        store=True,
+        readonly=False,
+        string="Model Name",
     )
     model_id = fields.Many2one(
         "ir.model", compute="_compute_template_fields", store=True, readonly=False


### PR DESCRIPTION
In `mgmtsystem.evaluation` model, fields `model` and `model_id` didn't have explicit string. So, Odoo calculated automatically Model for both, throwing a warning when installing or updating the module:

`Two fields (model_id, model) of mgmtsystem.evaluation() have the same label: Model. [Modules: mgmtsystem_evaluation and mgmtsystem_evaluation] `

Just wrote explicit string for `model` field in order to avoid the warning message.
