### PR TITLE
[15.0][FIX] mgmtsystem*: Define sequence without company

### DIFF
--- a/mgmtsystem_action/data/action_sequence.xml
+++ b/mgmtsystem_action/data/action_sequence.xml
@@ -4,5 +4,6 @@
       <field name="name">Management System Action</field>
       <field name="code">mgmtsystem.action</field>
       <field name="padding">3</field>
+      <field name="company_id" eval="False" />
     </record>
 </odoo>

--- a/mgmtsystem_audit/data/audit_sequence.xml
+++ b/mgmtsystem_audit/data/audit_sequence.xml
@@ -7,6 +7,7 @@
         <field name="code">mgmtsystem.audit</field>
         <field name="prefix">MSA</field>
         <field name="padding">3</field>
+        <field name="company_id" eval="False" />
     </record>
 
 </odoo>

--- a/mgmtsystem_claim/data/claim_sequence.xml
+++ b/mgmtsystem_claim/data/claim_sequence.xml
@@ -5,6 +5,7 @@
         <field name="name">Management System Claim</field>
         <field name="code">mgmtsystem.claim</field>
         <field name="padding">3</field>
+        <field name="company_id" eval="False" />
     </record>
 
 </odoo>

--- a/mgmtsystem_nonconformity/data/sequence.xml
+++ b/mgmtsystem_nonconformity/data/sequence.xml
@@ -5,6 +5,7 @@
         <field name="name">Management System Nonconformity</field>
         <field name="code">mgmtsystem.nonconformity</field>
         <field name="padding">3</field>
+        <field name="company_id" eval="False" />
     </record>
 
 </odoo>

--- a/mgmtsystem_review/data/ir_sequence.xml
+++ b/mgmtsystem_review/data/ir_sequence.xml
@@ -5,5 +5,6 @@
         <field name="code">mgmtsystem.review</field>
         <field name="prefix">MSR</field>
         <field name="padding">3</field>
+        <field name="company_id" eval="False" />
     </record>
 </odoo>


### PR DESCRIPTION
Define sequence without company

It is important to define sequences without company so that if there are several companies, the same sequence is used in all of them.

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

@Tecnativa