### PR TITLE
[18.0][FIX] mgmtsystem_hazard_risk: Remove required=True from the risk_computation_id field in res.config.settings to avoid side effects

### DIFF
--- a/mgmtsystem_hazard_risk/views/res_config_settings_views.xml
+++ b/mgmtsystem_hazard_risk/views/res_config_settings_views.xml
@@ -27,7 +27,6 @@
                             <div class="mt16">
                                 <field
                                     name="risk_computation_id"
-                                    required="1"
                                     class="o_light_label"
                                     domain="[('company_id', '=', company_id)]"
                                     context="{'default_company_id': company_id}"


### PR DESCRIPTION
FWP from 17.0: https://github.com/OCA/management-system/pull/699

Remove required=True from the `risk_computation_id` field in `res.config.settings` to avoid side effects

Use case:
- Install `mgmtsystem_hazard_risk` + `sale_product_matrix_secondary_unit`
- Run the `sale_product_matrix_secondary_unit` tests

```
File "/opt/odoo/auto/addons/sale_product_matrix_secondary_unit/tests/test_sale_product_matrix_secondary_unit.py", line 13, in setUpClass
    config = config.save()
  File "/opt/odoo/custom/src/odoo/odoo/tests/common.py", line 2230, in save
    values = self._values_to_save()
  File "/opt/odoo/custom/src/odoo/odoo/tests/common.py", line 2257, in _values_to_save
    return self._values_to_save_(
  File "/opt/odoo/custom/src/odoo/odoo/tests/common.py", line 2295, in _values_to_save_
    raise AssertionError("{} is a required field ({})".format(f, view['modifiers'][f]))
AssertionError: risk_computation_id is a required field ({'required': True})
```

Please @pedrobaeza can you review it?

@Tecnativa