### PR TITLE
[18.0][FIX] mgmtsystem*: Define sequence without company

### DIFF
--- a/mgmtsystem_action/data/action_sequence.xml
+++ b/mgmtsystem_action/data/action_sequence.xml
@@ -4,5 +4,6 @@
         <field name="name">Management System Action</field>
         <field name="code">mgmtsystem.action</field>
         <field name="padding">3</field>
+        <field name="company_id" eval="False" />
     </record>
 </odoo>

--- a/mgmtsystem_audit/data/audit_sequence.xml
+++ b/mgmtsystem_audit/data/audit_sequence.xml
@@ -6,5 +6,6 @@
         <field name="code">mgmtsystem.audit</field>
         <field name="prefix">MSA</field>
         <field name="padding">3</field>
+        <field name="company_id" eval="False" />
     </record>
 </odoo>

--- a/mgmtsystem_nonconformity/data/sequence.xml
+++ b/mgmtsystem_nonconformity/data/sequence.xml
@@ -3,5 +3,6 @@
         <field name="name">Management System Nonconformity</field>
         <field name="code">mgmtsystem.nonconformity</field>
         <field name="padding">3</field>
+        <field name="company_id" eval="False" />
     </record>
 </odoo>

--- a/mgmtsystem_review/data/ir_sequence.xml
+++ b/mgmtsystem_review/data/ir_sequence.xml
@@ -5,5 +5,6 @@
         <field name="code">mgmtsystem.review</field>
         <field name="prefix">MSR</field>
         <field name="padding">3</field>
+        <field name="company_id" eval="False" />
     </record>
 </odoo>


### PR DESCRIPTION
FWP from 17.0: https://github.com/OCA/management-system/pull/704

Define sequence without company

It is important to define sequences without company so that if there are several companies, the same sequence is used in all of them.

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

@Tecnativa