### PR TITLE
[18.0] [FIX] mgmtsystem_nonconformity: fixed access permission error

### DIFF
--- a/mgmtsystem_nonconformity/models/mail_thread.py
+++ b/mgmtsystem_nonconformity/models/mail_thread.py
@@ -40,10 +40,11 @@ class MailThread(models.AbstractModel):
 
     def _thread_to_store(self, store: Store, /, *, request_list=None, **kwargs):
         result = super()._thread_to_store(store, request_list=request_list, **kwargs)
-        for thread in self:
-            store.add(
-                thread,
-                {"non_conformity_count": thread.non_conformity_count},
-                as_thread=True,
-            )
+        if self.env.user.has_group("mgmtsystem.group_mgmtsystem_viewer"):
+            for thread in self:
+                store.add(
+                    thread,
+                    {"non_conformity_count": thread.non_conformity_count},
+                    as_thread=True,
+                )
         return result


### PR DESCRIPTION
To fix access permission error when user haven't mgmtsystem_viewer permission:

<img width="1915" height="664" alt="image" src="https://github.com/user-attachments/assets/95c6caa8-fbe5-4ab0-b473-2fcc6d9b9be7" />
