### PR TITLE
[16.0][FIX] mgmtsystem_nonconformity: stop breaking chatter from other modules

### DIFF
--- a/mgmtsystem_nonconformity/static/src/components/chatter_topbar/chatter_topbar.xml
+++ b/mgmtsystem_nonconformity/static/src/components/chatter_topbar/chatter_topbar.xml
@@ -16,7 +16,7 @@
                 type="button"
                 t-att-disabled="!chatterTopbar.chatter.isTemporary and !chatterTopbar.chatter.hasWriteAccess"
                 t-on-click="() => this.chatterTopbar.chatter.onClickShowNonConformities()"
-                t-if="chatterTopbar.chatter.webRecord.data.non_conformity_count !== undefined"
+                t-if="chatterTopbar.chatter.webRecord and chatterTopbar.chatter.webRecord.data.non_conformity_count !== undefined"
             >
                 <i
                     class="fa fa-exclamation-triangle fa-lg me-1"


### PR DESCRIPTION
Currently breaking chatter from account_reconcile_oca chatter (at least)