### PR TITLE
[16.0][IMP] mgmtsystem_evaluation: only manager should reset to draft

### DIFF
--- a/mgmtsystem_evaluation/views/mgmtsystem_evaluation.xml
+++ b/mgmtsystem_evaluation/views/mgmtsystem_evaluation.xml
@@ -32,6 +32,7 @@
                         string="Back to draft"
                         attrs="{'invisible': [('state', '=', 'draft')]}"
                         type="object"
+                        groups="mgmtsystem.group_mgmtsystem_manager"
                     />
                     <field name="state" widget="statusbar" />
                 </header>


### PR DESCRIPTION
A normal user can perform all actions, but the only ones they should be allowed to do are initiating or canceling an evaluation.