### PR TITLE
[18.0] [FIX] management_system: Update kanban view

### DIFF
--- a/mgmtsystem_action/models/mgmtsystem_action.py
+++ b/mgmtsystem_action/models/mgmtsystem_action.py
@@ -5,6 +5,13 @@ from datetime import datetime, timedelta
 
 from odoo import api, exceptions, fields, models
 
+TYPE_COLOR_MAP = {
+    "immediate": 1,
+    "correction": 2,
+    "prevention": 4,
+    "improvement": 10,
+}
+
 
 class MgmtsystemAction(models.Model):
     _name = "mgmtsystem.action"
@@ -53,6 +60,11 @@ class MgmtsystemAction(models.Model):
         "Response Type",
         required=True,
     )
+    color = fields.Integer(
+        "Color Index",
+        compute="_compute_color",
+        default=0,
+    )
     stage_id = fields.Many2one(
         "mgmtsystem.action.stage",
         "Stage",
@@ -92,6 +104,11 @@ class MgmtsystemAction(models.Model):
             action.number_of_days_to_close = action._elapsed_days(
                 action.create_date, action.date_closed
             )
+
+    @api.depends("type_action")
+    def _compute_color(self):
+        for action in self:
+            action.color = TYPE_COLOR_MAP[action.type_action]
 
     @api.model
     def _stage_groups(self, stages=None, domain=None, order=None):

--- a/mgmtsystem_action/tests/test_create_action.py
+++ b/mgmtsystem_action/tests/test_create_action.py
@@ -47,6 +47,7 @@ class TestModelAction(common.TransactionCase):
             }
         )
         self.assertEqual(new_record.reference, self.env._("SampleReference"))
+        self.assertEqual(self.record.color, 1)
 
     def test_case_close(self):
         """Test object close state."""

--- a/mgmtsystem_action/views/mgmtsystem_action.xml
+++ b/mgmtsystem_action/views/mgmtsystem_action.xml
@@ -187,141 +187,82 @@
         <field name="name">mgmtsystem.action.kanban</field>
         <field name="model">mgmtsystem.action</field>
         <field name="arch" type="xml">
-            <kanban default_group_by="stage_id" class="o_kanban_small_column">
-                <field name="name" />
-                <field name="priority" />
-                <field name="tag_ids" />
-                <field name="sequence" />
-                <field name="type_action" />
-                <field name="reference" />
-                <field name="user_id" />
-                <field name="create_date" />
-                <field name="date_deadline" />
-                <field name="activity_ids" />
-                <field name="activity_state" />
+            <kanban
+                highlight_color="color"
+                default_group_by="stage_id"
+                default_order="sequence,name desc"
+                records_draggable="True"
+            >
                 <field name="message_needaction_counter" />
                 <templates>
-                    <field name="date_deadline" />
+                    <t t-name="menu" groups="base.group_user">
+                        <t t-if="widget.editable">
+                            <a
+                                role="menuitem"
+                                type="edit"
+                                class="dropdown-item"
+                            >Edit</a>
+                        </t>
+                        <t t-if="widget.deletable">
+                            <a
+                                role="menuitem"
+                                type="delete"
+                                class="dropdown-item"
+                            >Delete</a>
+                        </t>
+                    </t>
                     <t t-name="card">
-                        <t t-set="type_action_color">#ffffff</t>
-                        <t
-                            t-if="record.type_action.raw_value and record.type_action.raw_value == 'immediate'"
-                            t-set="type_action_color"
-                        >oe_kanban_text_red</t>
-                        <t
-                            t-if="record.type_action.raw_value and record.type_action.raw_value == 'correction'"
-                            t-set="type_action_color"
-                        >#ffa500</t>
-                        <t
-                            t-if="record.type_action.raw_value and record.type_action.raw_value == 'prevention'"
-                            t-set="type_action_color"
-                        >#00ff00</t>
-                        <t
-                            t-if="record.type_action.raw_value and record.type_action.raw_value == 'improvement'"
-                            t-set="type_action_color"
-                        >#0000ff</t>
-                        <div
-                            t-attf-class="#{kanban_color(type_action_color)} oe_kanban_global_click"
-                        >
-                            <div class="oe_kanban_content">
-                                <div class="o_kanban_record_top">
-                                    <div class="o_kanban_record_headings">
-                                        <strong class="o_kanban_record_title">
-                                            <field name="name" />
-                                        </strong>
-                                        <br />
-                                        <small
-                                            class="o_kanban_record_subtitle text-muted"
-                                        >
-                                            <field
-                                                name="system_id"
-                                                invisible="context.get('default_system_id', False)"
-                                            />
-                                            <t
-                                                t-if="record.date_deadline.raw_value and record.date_deadline.raw_value lt (new Date())"
-                                                t-set="red"
-                                            >oe_kanban_text_red</t>
-                                            <span t-attf-class="#{red || ''}">
-                                                <i>
-                                                    <field name="date_deadline" />
-                                                </i>
-                                            </span>
-                                        </small>
-                                    </div>
-
-                                    <div
-                                        class="o_dropdown_kanban dropdown"
-                                        groups="base.group_user"
-                                    >
-                                        <a
-                                            class="dropdown-toggle o-no-caret btn"
-                                            role="button"
-                                            data-toggle="dropdown"
-                                            data-display="static"
-                                            href="#"
-                                            aria-label="Dropdown menu"
-                                            title="Dropdown menu"
-                                        >
-                                            <span class="fa fa-ellipsis-v" />
-                                        </a>
-                                        <div class="dropdown-menu" role="menu">
-                                            <t t-if="widget.editable">
-                                                <a
-                                                    role="menuitem"
-                                                    type="edit"
-                                                    class="dropdown-item"
-                                                >Edit Task</a>
-                                            </t>
-                                            <t t-if="widget.deletable">
-                                                <a
-                                                    role="menuitem"
-                                                    type="delete"
-                                                    class="dropdown-item"
-                                                >Delete</a>
-                                            </t>
-                                        </div>
-                                    </div>
-                                </div>
-
-                                <div class="o_kanban_record_body">
-                                    <field
-                                        name="tag_ids"
-                                        widget="many2many_tags"
-                                        options="{'color_field': 'color'}"
-                                    />
-                                </div>
-
-                                <div class="o_kanban_record_bottom">
-                                    <div class="oe_kanban_bottom_left">
-                                        <field name="priority" widget="priority" />
-                                        <field
-                                            name="activity_ids"
-                                            widget="kanban_activity"
-                                        />
-                                        <t
-                                            t-if="record.message_needaction_counter.raw_value"
-                                        >
-                                            <span
-                                                class='oe_kanban_mail_new'
-                                                title='Unread Messages'
-                                            >
-                                                <i class='fa fa-comments' />
-                                                <t
-                                                    t-out="record.message_needaction_counter.raw_value"
-                                                />
-                                            </span>
-                                        </t>
-                                    </div>
-                                    <div class="oe_kanban_bottom_right">
-                                        <field
-                                            name="user_id"
-                                            widget="many2one_avatar_user"
-                                        />
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="oe_clear" />
+                        <field class="fw-bold fs-5" name="name" />
+                        <div class="d-flex">
+                            <span
+                                class="flex-shrink-0 me-1"
+                            >[                                <field name="reference" />
+]</span>
+                            <field
+                                name="tag_ids"
+                                widget="many2many_tags"
+                                options="{'color_field': 'color'}"
+                            />
                         </div>
+                        <field
+                            name="system_id"
+                            class="text-muted text-truncate"
+                            invisible="context.get('default_system_id', False)"
+                        />
+
+                        <footer class="pt-1">
+                            <div class="d-flex mt-auto align-items-center">
+                                <field
+                                    name="priority"
+                                    widget="priority"
+                                    groups="base.group_user"
+                                    class="me-2"
+                                />
+                                <field name="activity_ids" widget="kanban_activity" />
+                                <t t-if="record.message_needaction_counter.raw_value">
+                                    <span
+                                        class="oe_kanban_mail_new"
+                                        title="Unread Messages"
+                                    >
+                                        <i class="fa fa-comments" />
+                                        <t
+                                            t-out="record.message_needaction_counter.raw_value"
+                                        />
+                                    </span>
+                                </t>
+                            </div>
+                            <field
+                                name="date_deadline"
+                                widget="remaining_days"
+                                class="ms-auto"
+                            />
+                            <field
+                                name="user_id"
+                                widget="many2one_avatar_user"
+                                domain="[('share', '=', False)]"
+                                class="ms-auto"
+                            />
+                        </footer>
                     </t>
                 </templates>
             </kanban>


### PR DESCRIPTION
Kanban view classes changed in v18
- This greatly simplifies kanban view to use flex classes
- Adds a type-color map dict  that maps to color index from o-colors in secondary_variables.scss (This removes hard coded colors, promotes uniformity and allows to easily override if needed)
- Adds computed color field to replace (not working kanban_color) card hightlight color
- Removes deprecated classes