### PR TITLE
[16.0][IMP] mgmtsystem_evaluation: allow update feedback and note

### DIFF
--- a/mgmtsystem_evaluation/models/mgmtsystem_evaluation.py
+++ b/mgmtsystem_evaluation/models/mgmtsystem_evaluation.py
@@ -138,9 +138,9 @@ class MgmtsystemEvaluation(models.Model):
                 record.res_id = False
                 record.model = template.model
                 record.model_id = template.model_id
-            if not record.feedback:
+            if record.feedback == "<p><br></p>" or not record.feedback:
                 record.feedback = template.feedback
-            if not record.note:
+            if record.note == "<p><br></p>" or not record.note:
                 record.note = template.note
 
     @api.depends("template_id")


### PR DESCRIPTION
Before, in an evaluation, when we chose a template and then changed it, the feedback and note fields weren’t updated, even if we cleared their content, because the HTML fields kept `<p><br/></p>`.