### PR TITLE
[17.0][IMP] mgmtsystem_audit: add button box to form view

### DIFF
--- a/mgmtsystem_audit/views/mgmtsystem_audit.xml
+++ b/mgmtsystem_audit/views/mgmtsystem_audit.xml
@@ -143,6 +143,7 @@
                     />
                     </header>
                     <sheet string="Audit">
+                        <div class="oe_button_box" name="button_box" />
                         <group col="4" colspan="2">
                             <field name="name" readonly="state == 'done'" />
                             <field name="reference" />


### PR DESCRIPTION
Adds a standard oe_button_box container to the audit form view, allowing other modules to inject smart buttons safely.