### PR TITLE
[19.0][FIX] mgmtsystem: fix manual module references in settings

### DIFF
--- a/mgmtsystem/i18n/mgmtsystem.pot
+++ b/mgmtsystem/i18n/mgmtsystem.pot
@@ -161,7 +161,7 @@ msgid "Information Security Manual"
 msgstr ""
 
 #. module: mgmtsystem
-#: model:ir.model.fields,field_description:mgmtsystem.field_res_config_settings__module_information_security_manual
+#: model:ir.model.fields,field_description:mgmtsystem.field_res_config_settings__module_mgmtsystem_info_security_manual
 msgid "Information Security Manual Template"
 msgstr ""
 
@@ -406,10 +406,10 @@ msgid ""
 msgstr ""
 
 #. module: mgmtsystem
-#: model:ir.model.fields,help:mgmtsystem.field_res_config_settings__module_information_security_manual
+#: model:ir.model.fields,help:mgmtsystem.field_res_config_settings__module_mgmtsystem_info_security_manual
 msgid ""
 "Provide an information security manual.\n"
-"- This installs the module information_security_manual."
+"- This installs the module mgmtsystem_info_security_manual."
 msgstr ""
 
 #. module: mgmtsystem

--- a/mgmtsystem/i18n/mgmtsystem.pot
+++ b/mgmtsystem/i18n/mgmtsystem.pot
@@ -133,7 +133,7 @@ msgid "Health & Safety Manual"
 msgstr ""
 
 #. module: mgmtsystem
-#: model:ir.model.fields,field_description:mgmtsystem.field_res_config_settings__module_mgmtsystem_health_safety_manual
+#: model:ir.model.fields,field_description:mgmtsystem.field_res_config_settings__module_document_page_health_safety_manual
 msgid "Health & Safety Manual Template"
 msgstr ""
 
@@ -368,10 +368,10 @@ msgid "Provide a Work Instruction documentation category and template."
 msgstr ""
 
 #. module: mgmtsystem
-#: model:ir.model.fields,help:mgmtsystem.field_res_config_settings__module_mgmtsystem_health_safety_manual
+#: model:ir.model.fields,help:mgmtsystem.field_res_config_settings__module_document_page_health_safety_manual
 msgid ""
 "Provide a health and safety manual template.\n"
-"- This installs the module mgmtsystem_health_safety_manual."
+"- This installs the module document_page_health_safety_manual."
 msgstr ""
 
 #. module: mgmtsystem
@@ -402,7 +402,7 @@ msgstr ""
 #: model:ir.model.fields,help:mgmtsystem.field_res_config_settings__module_document_page_environment_manual
 msgid ""
 "Provide an environment manual template.\n"
-"- This installs the module mgmtsystem_environment_manual."
+"- This installs the module document_page_environment_manual."
 msgstr ""
 
 #. module: mgmtsystem

--- a/mgmtsystem/models/res_config.py
+++ b/mgmtsystem/models/res_config.py
@@ -71,10 +71,10 @@ class MgmtsystemConfigSettings(models.TransientModel):
         help="Provide a health and safety manual template.\n"
         "- This installs the module document_page_health_safety_manual.",
     )
-    module_information_security_manual = fields.Boolean(
+    module_mgmtsystem_info_security_manual = fields.Boolean(
         "Information Security Manual Template",
         help="Provide an information security manual.\n"
-        "- This installs the module information_security_manual.",
+        "- This installs the module mgmtsystem_info_security_manual.",
     )
 
     # Documentation

--- a/mgmtsystem/models/res_config.py
+++ b/mgmtsystem/models/res_config.py
@@ -64,12 +64,12 @@ class MgmtsystemConfigSettings(models.TransientModel):
     module_document_page_environment_manual = fields.Boolean(
         "Environment Manual Template",
         help="Provide an environment manual template.\n"
-        "- This installs the module mgmtsystem_environment_manual.",
+        "- This installs the module document_page_environment_manual.",
     )
-    module_mgmtsystem_health_safety_manual = fields.Boolean(
+    module_document_page_health_safety_manual = fields.Boolean(
         "Health & Safety Manual Template",
         help="Provide a health and safety manual template.\n"
-        "- This installs the module mgmtsystem_health_safety_manual.",
+        "- This installs the module document_page_health_safety_manual.",
     )
     module_information_security_manual = fields.Boolean(
         "Information Security Manual Template",

--- a/mgmtsystem/views/res_config.xml
+++ b/mgmtsystem/views/res_config.xml
@@ -102,7 +102,7 @@
                             string="Information Security Manual"
                             help="Provide a Information Security Manual template based on the ISO 27001 standard."
                         >
-                            <field name="module_information_security_manual" />
+                            <field name="module_mgmtsystem_info_security_manual" />
                         </setting>
                     </block>
                     <block

--- a/mgmtsystem/views/res_config.xml
+++ b/mgmtsystem/views/res_config.xml
@@ -96,7 +96,7 @@
                             string="Health &amp; Safety Manual"
                             help="Provide a Health &amp; Safety Manual template based on the ISO 45001 / OHSAS 18001 standard."
                         >
-                            <field name="module_mgmtsystem_health_safety_manual" />
+                            <field name="module_document_page_health_safety_manual" />
                         </setting>
                         <setting
                             string="Information Security Manual"


### PR DESCRIPTION
## Summary
- Fix stale module names in `mgmtsystem` settings for environment and health & safety manual templates.
- Rename `module_mgmtsystem_health_safety_manual` to `module_document_page_health_safety_manual` so Odoo installs the correct addon.
- Update help text and translation template to reference `document_page_environment_manual` and `document_page_health_safety_manual`.

## Test plan
- [x] Open Management Systems settings and confirm Environment Manual and Health & Safety Manual toggles are displayed.
- [x] Enable Environment Manual and verify `document_page_environment_manual` is installed.
- [x] Enable Health & Safety Manual and verify the settings action references `document_page_health_safety_manual` (module install will succeed once that addon is migrated to 19.0).


Made with [Cursor](https://cursor.com)