### PR TITLE
[19.0][IMP] mgmtsystem_security_event: use mgmtsystem_risk for probability/severity

### DIFF
--- a/mgmtsystem_security_event/README.rst
+++ b/mgmtsystem_security_event/README.rst
@@ -173,6 +173,7 @@ Authors
 -------
 
 * Savoir-faire Linux
+* Gray Matter Logic
 
 Contributors
 ------------
@@ -200,6 +201,14 @@ This module is maintained by the OCA.
 OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.
+
+.. |maintainer-max3903| image:: https://github.com/max3903.png?size=40px
+    :target: https://github.com/max3903
+    :alt: max3903
+
+Current `maintainer <https://odoo-community.org/page/maintainer-role>`__:
+
+|maintainer-max3903| 
 
 This module is part of the `OCA/management-system <https://github.com/OCA/management-system/tree/19.0/mgmtsystem_security_event>`_ project on GitHub.
 

--- a/mgmtsystem_security_event/__manifest__.py
+++ b/mgmtsystem_security_event/__manifest__.py
@@ -3,15 +3,17 @@
 
 {
     "name": "Feared Events",
-    "version": "19.0.1.0.0",
-    "author": "Savoir-faire Linux, Odoo Community Association (OCA)",
+    "version": "19.0.2.0.0",
+    "author": "Savoir-faire Linux, Gray Matter Logic, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/management-system",
     "license": "AGPL-3",
     "category": "Management Systems",
+    "development_status": "Beta",
+    "maintainers": ["max3903"],
     "depends": [
         "mgmtsystem",
         "document_page",
-        "mgmtsystem_hazard",
+        "mgmtsystem_risk",
     ],
     "data": [
         "data/document_page.xml",

--- a/mgmtsystem_security_event/demo/mgmtsystem_security_event.xml
+++ b/mgmtsystem_security_event/demo/mgmtsystem_security_event.xml
@@ -73,18 +73,12 @@
         <field
             name="description"
         >Attacker gains access to the customer database.</field>
-        <field
-            name="original_probability_id"
-            ref="mgmtsystem_hazard.probability_probably"
-        />
-        <field name="original_severity_id" ref="mgmtsystem_hazard.severity_critical" />
-        <field
-            name="current_probability_id"
-            ref="mgmtsystem_hazard.probability_maybe"
-        />
-        <field name="current_severity_id" ref="mgmtsystem_hazard.severity_heavy" />
-        <field name="residual_probability_id" ref="mgmtsystem_hazard.probability_low" />
-        <field name="residual_severity_id" ref="mgmtsystem_hazard.severity_medium" />
+        <field name="original_probability_id" ref="mgmtsystem_risk.probability_high" />
+        <field name="original_severity_id" ref="mgmtsystem_risk.severity_critical" />
+        <field name="current_probability_id" ref="mgmtsystem_risk.probability_medium" />
+        <field name="current_severity_id" ref="mgmtsystem_risk.severity_high" />
+        <field name="residual_probability_id" ref="mgmtsystem_risk.probability_low" />
+        <field name="residual_severity_id" ref="mgmtsystem_risk.severity_medium" />
         <field name="system_id" ref="demo_security_system" />
         <field
             name="supporting_asset_ids"
@@ -97,13 +91,13 @@
         <field name="description">Application server becomes unavailable.</field>
         <field
             name="original_probability_id"
-            ref="mgmtsystem_hazard.probability_maybe"
+            ref="mgmtsystem_risk.probability_medium"
         />
-        <field name="original_severity_id" ref="mgmtsystem_hazard.severity_heavy" />
-        <field name="current_probability_id" ref="mgmtsystem_hazard.probability_low" />
-        <field name="current_severity_id" ref="mgmtsystem_hazard.severity_medium" />
-        <field name="residual_probability_id" ref="mgmtsystem_hazard.probability_low" />
-        <field name="residual_severity_id" ref="mgmtsystem_hazard.severity_simple" />
+        <field name="original_severity_id" ref="mgmtsystem_risk.severity_high" />
+        <field name="current_probability_id" ref="mgmtsystem_risk.probability_low" />
+        <field name="current_severity_id" ref="mgmtsystem_risk.severity_medium" />
+        <field name="residual_probability_id" ref="mgmtsystem_risk.probability_low" />
+        <field name="residual_severity_id" ref="mgmtsystem_risk.severity_low" />
         <field name="system_id" ref="demo_security_system" />
         <field
             name="supporting_asset_ids"
@@ -118,13 +112,13 @@
         >Attacker alters records in the customer database.</field>
         <field
             name="original_probability_id"
-            ref="mgmtsystem_hazard.probability_maybe"
+            ref="mgmtsystem_risk.probability_medium"
         />
-        <field name="original_severity_id" ref="mgmtsystem_hazard.severity_heavy" />
-        <field name="current_probability_id" ref="mgmtsystem_hazard.probability_low" />
-        <field name="current_severity_id" ref="mgmtsystem_hazard.severity_medium" />
-        <field name="residual_probability_id" ref="mgmtsystem_hazard.probability_low" />
-        <field name="residual_severity_id" ref="mgmtsystem_hazard.severity_simple" />
+        <field name="original_severity_id" ref="mgmtsystem_risk.severity_high" />
+        <field name="current_probability_id" ref="mgmtsystem_risk.probability_low" />
+        <field name="current_severity_id" ref="mgmtsystem_risk.severity_medium" />
+        <field name="residual_probability_id" ref="mgmtsystem_risk.probability_low" />
+        <field name="residual_severity_id" ref="mgmtsystem_risk.severity_low" />
         <field name="system_id" ref="demo_security_system" />
         <field
             name="supporting_asset_ids"
@@ -162,7 +156,7 @@
         <field name="confidentiality" eval="True" />
         <field name="integrity" eval="True" />
         <field name="availability" eval="False" />
-        <field name="severity_id" ref="mgmtsystem_hazard.severity_critical" />
+        <field name="severity_id" ref="mgmtsystem_risk.severity_critical" />
         <field
             name="content"
         ><![CDATA[
@@ -199,7 +193,7 @@
         <field name="confidentiality" eval="False" />
         <field name="integrity" eval="False" />
         <field name="availability" eval="True" />
-        <field name="severity_id" ref="mgmtsystem_hazard.severity_heavy" />
+        <field name="severity_id" ref="mgmtsystem_risk.severity_high" />
         <field
             name="content"
         ><![CDATA[
@@ -238,7 +232,7 @@
         <field name="confidentiality" eval="False" />
         <field name="integrity" eval="True" />
         <field name="availability" eval="False" />
-        <field name="severity_id" ref="mgmtsystem_hazard.severity_heavy" />
+        <field name="severity_id" ref="mgmtsystem_risk.severity_high" />
         <field
             name="content"
         ><![CDATA[

--- a/mgmtsystem_security_event/migrations/19.0.2.0.0/pre-migrate.py
+++ b/mgmtsystem_security_event/migrations/19.0.2.0.0/pre-migrate.py
@@ -1,0 +1,104 @@
+# Copyright (C) 2025 Gray Matter Logic (<https://www.graymatterlogic.com>).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openupgradelib import openupgrade
+
+_HAZARD_PROB_TABLE = "mgmtsystem_hazard_probability"
+_HAZARD_SEV_TABLE = "mgmtsystem_hazard_severity"
+_RISK_PROB_TABLE = "mgmtsystem_risk_probability"
+_RISK_SEV_TABLE = "mgmtsystem_risk_severity"
+
+_TABLES_FIELDS = {
+    "mgmtsystem_security_event": [
+        "severity_id",
+        "original_probability_id",
+        "original_severity_id",
+        "current_probability_id",
+        "current_severity_id",
+        "residual_probability_id",
+        "residual_severity_id",
+    ],
+    "mgmtsystem_security_vector": [
+        "original_probability_id",
+        "original_severity_id",
+        "current_probability_id",
+        "current_severity_id",
+        "residual_probability_id",
+        "residual_severity_id",
+    ],
+    "mgmtsystem_security_event_scenario": ["probability_id"],
+}
+
+
+def _build_id_map(cr, hazard_table, risk_table):
+    openupgrade.logged_query(
+        cr,
+        f"""
+        SELECT h.id AS old_id, r.id AS new_id
+          FROM {hazard_table} h
+          JOIN {risk_table} r
+            ON h.value = r.value
+           AND COALESCE(h.company_id, 0) = COALESCE(r.company_id, 0)
+        """,
+    )
+    return dict(cr.fetchall())
+
+
+def _ensure_risk_records(cr, hazard_table, risk_table):
+    openupgrade.logged_query(
+        cr,
+        f"""
+        INSERT INTO {risk_table} (
+            company_id, name, value, description,
+            create_uid, create_date, write_uid, write_date
+        )
+        SELECT h.company_id, h.name, h.value, h.description,
+               h.create_uid, h.create_date, h.write_uid, h.write_date
+          FROM {hazard_table} h
+         WHERE NOT EXISTS (
+               SELECT 1
+                 FROM {risk_table} r
+                WHERE r.value = h.value
+                  AND COALESCE(r.company_id, 0) = COALESCE(h.company_id, 0)
+               )
+        """,
+    )
+
+
+def _remap_foreign_keys(cr, table, fields, id_map):
+    for field in fields:
+        for old_id, new_id in id_map.items():
+            if old_id == new_id:
+                continue
+            openupgrade.logged_query(
+                cr,
+                f"""
+                UPDATE {table}
+                   SET {field} = %s
+                 WHERE {field} = %s
+                """,
+                (new_id, old_id),
+            )
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    cr = env.cr
+    if not openupgrade.table_exists(cr, _HAZARD_PROB_TABLE):
+        return
+    if not openupgrade.table_exists(cr, _RISK_PROB_TABLE):
+        return
+
+    _ensure_risk_records(cr, _HAZARD_PROB_TABLE, _RISK_PROB_TABLE)
+    _ensure_risk_records(cr, _HAZARD_SEV_TABLE, _RISK_SEV_TABLE)
+
+    prob_map = _build_id_map(cr, _HAZARD_PROB_TABLE, _RISK_PROB_TABLE)
+    sev_map = _build_id_map(cr, _HAZARD_SEV_TABLE, _RISK_SEV_TABLE)
+
+    for table, fields in _TABLES_FIELDS.items():
+        if not openupgrade.table_exists(cr, table):
+            continue
+        prob_fields = [field for field in fields if "probability" in field]
+        sev_fields = [field for field in fields if "severity" in field]
+        _remap_foreign_keys(cr, table, prob_fields, prob_map)
+        _remap_foreign_keys(cr, table, sev_fields, sev_map)

--- a/mgmtsystem_security_event/models/mgmtsystem_security_event.py
+++ b/mgmtsystem_security_event/models/mgmtsystem_security_event.py
@@ -31,7 +31,7 @@ class FearedEvents(models.Model):
         readonly=True,
         store=True,
     )
-    severity_id = fields.Many2one("mgmtsystem.hazard.severity")
+    severity_id = fields.Many2one("mgmtsystem.risk.severity")
     scenario_ids = fields.One2many(
         "mgmtsystem.security.event.scenario",
         "security_event_id",
@@ -44,32 +44,32 @@ class FearedEvents(models.Model):
     integrity = fields.Boolean()
     availability = fields.Boolean()
     original_probability_id = fields.Many2one(
-        "mgmtsystem.hazard.probability",
+        "mgmtsystem.risk.probability",
         compute="_compute_ratings",
         store=True,
     )
     original_severity_id = fields.Many2one(
-        "mgmtsystem.hazard.severity",
+        "mgmtsystem.risk.severity",
         compute="_compute_ratings",
         store=True,
     )
     current_probability_id = fields.Many2one(
-        "mgmtsystem.hazard.probability",
+        "mgmtsystem.risk.probability",
         compute="_compute_ratings",
         store=True,
     )
     current_severity_id = fields.Many2one(
-        "mgmtsystem.hazard.severity",
+        "mgmtsystem.risk.severity",
         compute="_compute_ratings",
         store=True,
     )
     residual_probability_id = fields.Many2one(
-        "mgmtsystem.hazard.probability",
+        "mgmtsystem.risk.probability",
         compute="_compute_ratings",
         store=True,
     )
     residual_severity_id = fields.Many2one(
-        "mgmtsystem.hazard.severity",
+        "mgmtsystem.risk.severity",
         compute="_compute_ratings",
         store=True,
     )

--- a/mgmtsystem_security_event/models/mgmtsystem_security_event_scenario.py
+++ b/mgmtsystem_security_event/models/mgmtsystem_security_event_scenario.py
@@ -11,7 +11,7 @@ class EventScenarioLines(models.Model):
     description = fields.Text()
     vector_id = fields.Many2one("mgmtsystem.security.vector")
     source_id = fields.Many2one("mgmtsystem.security.threat.source")
-    probability_id = fields.Many2one("mgmtsystem.hazard.probability")
+    probability_id = fields.Many2one("mgmtsystem.risk.probability")
     security_event_id = fields.Many2one("mgmtsystem.security.event")
     system_id = fields.Many2one(
         related="security_event_id.system_id",

--- a/mgmtsystem_security_event/models/mgmtsystem_security_vector.py
+++ b/mgmtsystem_security_event/models/mgmtsystem_security_vector.py
@@ -17,27 +17,27 @@ class Vector(models.Model):
         "supporting_asset_id",
     )
     original_probability_id = fields.Many2one(
-        "mgmtsystem.hazard.probability",
+        "mgmtsystem.risk.probability",
         help="Probability without any control",
     )
     original_severity_id = fields.Many2one(
-        "mgmtsystem.hazard.severity",
+        "mgmtsystem.risk.severity",
         help="Severity without any control",
     )
     current_probability_id = fields.Many2one(
-        "mgmtsystem.hazard.probability",
+        "mgmtsystem.risk.probability",
         help="Probability with existing controls",
     )
     current_severity_id = fields.Many2one(
-        "mgmtsystem.hazard.severity",
+        "mgmtsystem.risk.severity",
         help="Severity with existing controls",
     )
     residual_probability_id = fields.Many2one(
-        "mgmtsystem.hazard.probability",
+        "mgmtsystem.risk.probability",
         help="Probability after remediation",
     )
     residual_severity_id = fields.Many2one(
-        "mgmtsystem.hazard.severity",
+        "mgmtsystem.risk.severity",
         help="Severity after remediation",
     )
 

--- a/mgmtsystem_security_event/static/description/index.html
+++ b/mgmtsystem_security_event/static/description/index.html
@@ -522,6 +522,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <h3><a class="toc-backref" href="#toc-entry-12">Authors</a></h3>
 <ul class="simple">
 <li>Savoir-faire Linux</li>
+<li>Gray Matter Logic</li>
 </ul>
 </div>
 <div class="section" id="contributors">
@@ -549,6 +550,8 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>
+<p>Current <a class="reference external" href="https://odoo-community.org/page/maintainer-role">maintainer</a>:</p>
+<p><a class="reference external image-reference" href="https://github.com/max3903"><img alt="max3903" src="https://github.com/max3903.png?size=40px" /></a></p>
 <p>This module is part of the <a class="reference external" href="https://github.com/OCA/management-system/tree/19.0/mgmtsystem_security_event">OCA/management-system</a> project on GitHub.</p>
 <p>You are welcome to contribute. To learn how please visit <a class="reference external" href="https://odoo-community.org/page/Contribute">https://odoo-community.org/page/Contribute</a>.</p>
 </div>

--- a/mgmtsystem_security_event/tests/test_models.py
+++ b/mgmtsystem_security_event/tests/test_models.py
@@ -98,10 +98,10 @@ class TestScenarioDisplayName(TestModelsBase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        prob = cls.env["mgmtsystem.hazard.probability"].create(
+        prob = cls.env["mgmtsystem.risk.probability"].create(
             {"name": "Low", "value": 1}
         )
-        sev = cls.env["mgmtsystem.hazard.severity"].create({"name": "Low", "value": 1})
+        sev = cls.env["mgmtsystem.risk.severity"].create({"name": "Low", "value": 1})
         cls.vector = cls.env["mgmtsystem.security.vector"].create(
             {
                 "name": "Phishing",
@@ -249,12 +249,10 @@ class TestSecurityEventNoScenarios(TestModelsBase):
         self.assertFalse(event.residual_severity_id)
 
     def test_ratings_clear_when_scenarios_removed(self):
-        prob = self.env["mgmtsystem.hazard.probability"].create(
+        prob = self.env["mgmtsystem.risk.probability"].create(
             {"name": "High", "value": 4}
         )
-        sev = self.env["mgmtsystem.hazard.severity"].create(
-            {"name": "High", "value": 4}
-        )
+        sev = self.env["mgmtsystem.risk.severity"].create({"name": "High", "value": 4})
         vector = self.env["mgmtsystem.security.vector"].create(
             {
                 "name": "Test vector",

--- a/mgmtsystem_security_event/tests/test_security_event.py
+++ b/mgmtsystem_security_event/tests/test_security_event.py
@@ -10,8 +10,8 @@ class TestSecurityEventBase(common.TransactionCase):
         super().setUpClass()
         cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
         cls.system = cls.env["mgmtsystem.system"].create({"name": "Security System"})
-        cls.probability_model = cls.env["mgmtsystem.hazard.probability"]
-        cls.severity_model = cls.env["mgmtsystem.hazard.severity"]
+        cls.probability_model = cls.env["mgmtsystem.risk.probability"]
+        cls.severity_model = cls.env["mgmtsystem.risk.severity"]
         cls.vector_model = cls.env["mgmtsystem.security.vector"]
         cls.event_model = cls.env["mgmtsystem.security.event"]
 

--- a/mgmtsystem_security_event/wizards/mgmtsystem_risk_matrix.py
+++ b/mgmtsystem_security_event/wizards/mgmtsystem_risk_matrix.py
@@ -65,13 +65,13 @@ class MgmtsystemRiskMatrix(models.TransientModel):
         )
 
     def get_probabilities(self):
-        return self.env["mgmtsystem.hazard.probability"].search(
+        return self.env["mgmtsystem.risk.probability"].search(
             [("company_id", "in", (False, self.env.company.id))],
             order="value",
         )
 
     def get_severities(self):
-        return self.env["mgmtsystem.hazard.severity"].search(
+        return self.env["mgmtsystem.risk.severity"].search(
             [("company_id", "in", (False, self.env.company.id))],
             order="value desc",
         )


### PR DESCRIPTION
## Summary

- Replaces the dependency on `mgmtsystem_hazard` with `mgmtsystem_risk`, eliminating the cross-domain coupling where `mgmtsystem_security_event` (information security) was forced to depend on `mgmtsystem_hazard` (occupational health & safety) solely for probability/severity scales
- Updates all `Many2one` field definitions, the risk matrix wizard, tests, and demo data to reference `mgmtsystem.risk.probability` and `mgmtsystem.risk.severity`

## Dependencies

Requires PR #814 (`mgmtsystem_risk`) to be merged first.

## Test plan

- [x] Fresh install: install `mgmtsystem_risk` then `mgmtsystem_security_event` (without `mgmtsystem_hazard`) and verify probability/severity fields work on vectors and feared events
- [x] Verify the risk matrix wizard renders correctly with probability/severity from `mgmtsystem_risk`
- [x] Run unit tests: `odoo --test-enable --stop-after-init -d <db> -i mgmtsystem_security_event`

🤖 Generated with [Claude Code](https://claude.com/claude-code)