### PR TITLE
[IMP] mgmtsystem_nonconformity: replace related NC section by smart button

### DIFF
--- a/mgmtsystem_nonconformity/models/mgmtsystem_action.py
+++ b/mgmtsystem_nonconformity/models/mgmtsystem_action.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2010 Savoir-faire Linux (<http://www.savoirfairelinux.com>).
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import _, api, fields, models
 
 
 class MgmtsystemAction(models.Model):
@@ -18,3 +18,22 @@ class MgmtsystemAction(models.Model):
         "Nonconformities",
         readonly=True,
     )
+    nonconformity_count = fields.Integer(
+        compute="_compute_nonconformity_count",
+        string="Number of nonconformities",
+    )
+
+    @api.depends("nonconformity_ids")
+    def _compute_nonconformity_count(self):
+        for action in self:
+            action.nonconformity_count = len(action.nonconformity_ids)
+
+    def action_open_nonconformities(self):
+        self.ensure_one()
+        return {
+            "name": _("Nonconformities"),
+            "type": "ir.actions.act_window",
+            "res_model": "mgmtsystem.nonconformity",
+            "view_mode": "tree,form",
+            "domain": [("id", "in", self.nonconformity_ids.ids)],
+        }

--- a/mgmtsystem_nonconformity/tests/__init__.py
+++ b/mgmtsystem_nonconformity/tests/__init__.py
@@ -1,5 +1,6 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from . import test_action
 from . import test_cause
 from . import test_origin
 from . import test_nonconformity

--- a/mgmtsystem_nonconformity/tests/test_action.py
+++ b/mgmtsystem_nonconformity/tests/test_action.py
@@ -1,0 +1,43 @@
+# Copyright (C) 2010 Savoir-faire Linux (<http://www.savoirfairelinux.com>).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import common
+
+
+class TestMgmtsystemActionNonconformity(common.TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.partner = cls.env["res.partner"].create({"name": "Test Partner"})
+        cls.action = cls.env["mgmtsystem.action"].create(
+            {
+                "name": "Test Action",
+                "type_action": "immediate",
+            }
+        )
+        cls.nc = cls.env["mgmtsystem.nonconformity"].create(
+            {
+                "partner_id": cls.partner.id,
+                "manager_user_id": cls.env.user.id,
+                "responsible_user_id": cls.env.user.id,
+                "description": "Test nonconformity",
+            }
+        )
+
+    def test_nonconformity_count_no_nc(self):
+        """An action without nonconformities counts 0."""
+        self.assertEqual(self.action.nonconformity_count, 0)
+
+    def test_nonconformity_count_with_nc(self):
+        """Linking nonconformities increases the counter."""
+        self.nc.action_ids = [(6, 0, self.action.ids)]
+        self.assertEqual(self.action.nonconformity_count, 1)
+
+    def test_action_open_nonconformities(self):
+        """The smart button action returns the correct domain."""
+        self.nc.action_ids = [(6, 0, self.action.ids)]
+        result = self.action.action_open_nonconformities()
+        self.assertEqual(result["res_model"], "mgmtsystem.nonconformity")
+        self.assertEqual(
+            result["domain"], [("id", "in", self.action.nonconformity_ids.ids)]
+        )

--- a/mgmtsystem_nonconformity/views/mgmtsystem_action.xml
+++ b/mgmtsystem_nonconformity/views/mgmtsystem_action.xml
@@ -1,20 +1,28 @@
+<?xml version="1.0" encoding="utf-8" ?>
 <odoo>
-    <!-- Actions: add link to NCs -->
+    <!-- Actions: replace the related nonconformities section by a smart button -->
     <record id="view_mgmtsystem_action_form" model="ir.ui.view">
         <field name="name">mgmtsystem.action.form</field>
         <field name="model">mgmtsystem.action</field>
         <field name="inherit_id" ref="mgmtsystem_action.view_mgmtsystem_action_form" />
+        <field name="priority">99</field>
         <field name="arch" type="xml">
-            <field name="description" position="after">
-                <separator string="Related Nonconformities" colspan="4" />
-                <field
-                    name="nonconformity_ids"
-                    colspan="4"
-                    nolabel="1"
-                    invisible="nonconformity_ids == False"
-                    readonly="1"
-                />
-            </field>
+            <!-- Add a smart button that opens the linked nonconformities -->
+            <xpath expr="//div[@name='button_box']" position="inside">
+                <button
+                    name="action_open_nonconformities"
+                    type="object"
+                    class="oe_stat_button"
+                    icon="fa-exclamation-triangle"
+                    invisible="nonconformity_count == 0"
+                >
+                    <field
+                        name="nonconformity_count"
+                        string="Nonconformities"
+                        widget="statinfo"
+                    />
+                </button>
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
This change removes the 'Related Nonconformities' block from the action form view and adds a 'Nonconformities' smart button, visible only when the action is linked to at least one nonconformity.

Depends on the button-box addition to the action form view.