### PR TITLE
[17.0][FIX] mgmtsystem_nonconformity: use correct Odoo 17 kanban state widget

### DIFF
--- a/mgmtsystem_nonconformity/views/mgmtsystem_nonconformity.xml
+++ b/mgmtsystem_nonconformity/views/mgmtsystem_nonconformity.xml
@@ -185,7 +185,7 @@
                                 <div class="oe_kanban_bottom_right">
                                     <field
                                         name="kanban_state"
-                                        widget="kanban_state_selection"
+                                        widget="state_selection"
                                     />
                                     <field
                                         name="responsible_user_id"
@@ -214,7 +214,7 @@
                 </header>
                 <sheet string="Non-Conformity">
                     <div class="oe_button_box" name="button_box" />
-                    <field name="kanban_state" widget="kanban_state_selection" />
+                    <field name="kanban_state" widget="state_selection" />
                     <group name="main">
                         <group name="config">
                             <field name="name" readonly="state not in 'draft'" />


### PR DESCRIPTION
The widget `kanban_state_selection` does not exist in Odoo 17; it was renamed to `state_selection`. Because the old widget name is unknown, the `kanban_state` field on nonconformities falls back to a plain selection dropdown.

This PR updates both the kanban card and the form view to use the correct `state_selection` widget.