### PR TITLE
[17.0][IMP] mgmtsystem_audit: remove redundant number_of_audits measure

### DIFF
--- a/mgmtsystem_audit/report/mgmtsystem_audit_pivot.xml
+++ b/mgmtsystem_audit/report/mgmtsystem_audit_pivot.xml
@@ -8,7 +8,6 @@
                 <pivot string="Audit" disable_linking="True">
                     <field name="state" type="row" />
                     <field name="user_id" type="col" />
-                    <field name="number_of_audits" type="measure" />
                 </pivot>
             </field>
         </record>
@@ -22,7 +21,6 @@
                 <graph string="Audit">
                     <field name="state" />
                     <field name="user_id" />
-                    <field name="number_of_audits" type="measure" />
                 </graph>
             </field>
         </record>


### PR DESCRIPTION
Odoo's pivot and graph views already provide a default count measure. This removes the `number_of_audits` field from the audit analysis pivot and graph views so users see the standard Number measure instead.