### PR TITLE
[17.0][IMP] mgmtsystem_audit: make state statusbar clickable

### DIFF
--- a/mgmtsystem_audit/views/mgmtsystem_audit.xml
+++ b/mgmtsystem_audit/views/mgmtsystem_audit.xml
@@ -139,7 +139,7 @@
                         name="state"
                         widget="statusbar"
                         select="1"
-                        readonly="1"
+                        clickable="True"
                     />
                     </header>
                     <sheet string="Audit">


### PR DESCRIPTION
Allows users to change the audit state directly from the form view statusbar instead of relying only on the Close button.