### PR TITLE
[18.0][FIX] document_page_procedure: ref not exist

### DIFF
--- a/document_page_procedure/migrations/18.0.1.1.0/post-migration.py
+++ b/document_page_procedure/migrations/18.0.1.1.0/post-migration.py
@@ -3,6 +3,8 @@ from openupgradelib import openupgrade
 
 @openupgrade.migrate()
 def migrate(env, version):
-    env.ref("document_page_procedure.document_page_procedure").write(
-        {"mgmtsystem_page_type": "procedure"}
+    doc_group_id = env.ref(
+        "document_page_procedure.document_page_group_procedure", False
     )
+    if doc_group_id:
+        doc_group_id.write({"mgmtsystem_page_type": "procedure"})


### PR DESCRIPTION
in post-migrate:
 env.ref("document_page_procedure.document_page_procedure").write(
        {"mgmtsystem_page_type": "procedure"}
    )