### PR TITLE
[18.0][IMP] mgmtsystem_action: add button box to form view

### DIFF
--- a/mgmtsystem_action/views/mgmtsystem_action.xml
+++ b/mgmtsystem_action/views/mgmtsystem_action.xml
@@ -122,6 +122,7 @@
                     />
                 </header>
                 <sheet string="Action">
+                    <div class="oe_button_box" name="button_box" />
                     <div class="oe_title" modifiers="{}">
                         <h1 class="o_row" modifiers="{}">
                             <div class="d-flex">


### PR DESCRIPTION
Adds a standard oe_button_box container to the action form view, allowing other modules to inject smart buttons safely.

Port of #790 to 18.0.