### PR TITLE
[18.0][IMP] mgmtsystem_audit: add button box to form view

### DIFF
--- a/mgmtsystem_audit/views/mgmtsystem_audit.xml
+++ b/mgmtsystem_audit/views/mgmtsystem_audit.xml
@@ -132,6 +132,7 @@
                     <field name="state" widget="statusbar" select="1" readonly="1" />
                 </header>
                 <sheet string="Audit">
+                    <div class="oe_button_box" name="button_box" />
                     <group col="4" colspan="2">
                         <field name="name" readonly="state == 'done'" />
                         <field name="reference" />


### PR DESCRIPTION
Adds a standard oe_button_box container to the audit form view, allowing other modules to inject smart buttons safely.

Port of #791 to 18.0.