### PR TITLE
[IMP] mgmtsystem_audit: show reference as first column in audit list view

### DIFF
--- a/mgmtsystem_audit/views/mgmtsystem_audit.xml
+++ b/mgmtsystem_audit/views/mgmtsystem_audit.xml
@@ -75,10 +75,10 @@
         <field name="type">list</field>
         <field name="arch" type="xml">
             <list>
+                <field name="reference" />
                 <field name="name" readonly="state == 'done'" />
                 <field name="date" readonly="state == 'done'" />
                 <field name="create_date" />
-                <field name="reference" />
                 <field name="system_id" />
                 <field name="company_id" groups="base.group_multi_company" />
             </list>


### PR DESCRIPTION
Moves the audit reference field to the first column of the audit list view, making the audit code visible at a glance.