### PR TITLE
[14.0][FIX] mgmtsystem_claim: add invisible claim_type field to form view

### DIFF
--- a/mgmtsystem_claim/views/mgmtsystem_claim.xml
+++ b/mgmtsystem_claim/views/mgmtsystem_claim.xml
@@ -45,6 +45,7 @@
                         <field name="name" />
                         <field name="date" />
                         <field name="team_id" invisible="1" />
+                        <field name="claim_type" invisible="1" />
                     </group>
                     <group colspan="4" col="4" groups="base.group_user">
                         <field name="user_id" />


### PR DESCRIPTION
The `stage_id` field in the `mgmtsystem_claims_form_view` has a default domain that references `claim_type`.
This field must be present in the view, otherwise installation of `mgmtsystem_claim` fails with:

```
Field claim_type used in field stage_id default domain ... must be present in view but is missing.
```

This fix adds `<field name="claim_type" invisible="1"/>` to the form view.